### PR TITLE
Allow class_pred comparisons

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # probably (development version)
 
+* `class_pred` objects are now comparable and will be ordered by their levels.
+  Equivocal values are generally considered to be the smallest value when
+  ordering. `NA` values can be considered smaller if
+  `vec_order(na_value = "smallest")` is used.
+
 # probably 0.0.5
 
 * Internal cleanup to be more compatible with vctrs 0.3.0.

--- a/R/vctrs-compat.R
+++ b/R/vctrs-compat.R
@@ -219,5 +219,5 @@ vec_proxy_equal.class_pred <- function(x, ...) {
 
 #' @export
 vec_proxy_compare.class_pred <- function(x, ...) {
-  abort("Comparisons with `class_pred` objects are not meaningful.")
+  unclass(x)
 }

--- a/tests/testthat/test-vctrs-compat.R
+++ b/tests/testthat/test-vctrs-compat.R
@@ -1,0 +1,20 @@
+# ------------------------------------------------------------------------------
+# vec_proxy_compare()
+
+test_that("can take the comparison proxy", {
+  x <- class_pred(factor(c("a", "b", NA)), which = 2)
+  expect_identical(vec_proxy_compare(x), unclass(x))
+})
+
+# ------------------------------------------------------------------------------
+# vctrs miscellaneous
+
+test_that("can order by level with equivocal as smallest value using vec_order()", {
+  x <- factor(c("a", "b", NA, "b"), levels = c("b", "a"))
+  x <- class_pred(x, which = 2)
+
+  expect <- factor(c("b", "b", "a", NA), levels = c("b", "a"))
+  expect <- class_pred(expect, which = 1)
+
+  expect_identical(x[vec_order(x)], expect)
+})


### PR DESCRIPTION
Fixes compatibility with dplyr 1.0.0. A `group_by()` internally calls `vec_order()` which calls `vec_proxy_compare()`. So we can't group by class_pred without this. In the vignettes we weren't doing that directly, but we were calling `count(x, <class_pred>)` which groups by that column internally.