### PR TITLE
Specify metrics in threshold_perf()

### DIFF
--- a/man/threshold_perf.Rd
+++ b/man/threshold_perf.Rd
@@ -7,7 +7,15 @@
 \usage{
 threshold_perf(.data, ...)
 
-\method{threshold_perf}{data.frame}(.data, truth, estimate, thresholds = NULL, na_rm = TRUE, ...)
+\method{threshold_perf}{data.frame}(
+  .data,
+  truth,
+  estimate,
+  thresholds = NULL,
+  na_rm = TRUE,
+  ...,
+  metrics = NULL
+)
 }
 \arguments{
 \item{.data}{A tibble, potentially grouped.}
@@ -26,6 +34,8 @@ of values between 0.5 and 1.0 are used. \strong{Note}: if this
 argument is used, it must be named.}
 
 \item{na_rm}{A single logical: should missing data be removed?}
+
+\item{metrics}{A \code{\link[yardstick:metric_set]{yardstick::metric_set()}} of class metrics or \code{NULL}.}
 }
 \value{
 A tibble with columns: \code{.threshold}, \code{.estimator}, \code{.metric},
@@ -41,7 +51,7 @@ Note that that the global option \code{yardstick.event_first} will be
 used to determine which level is the event of interest. For more details,
 see the Relevant level section of \code{\link[yardstick:sens]{yardstick::sens()}}.
 
-The currently calculated metrics are:
+By default (when \code{metrics = NULL}) the calculated metrics are:
 \itemize{
 \item \code{\link[yardstick:j_index]{yardstick::j_index()}}
 \item \code{\link[yardstick:sens]{yardstick::sens()}}


### PR DESCRIPTION
## Description

So that the user can specify which metrics are computed when calling threshold_perf(), we add a new `metrics` argument that accepts a `yardstick` metric set.

By default this argument is `NULL`, in which case the function computes the default metrics. If not `NULL`, the function checks that it's an appropriate metric set (class metrics only) and computes only the metrics provided in the set.

## Motivation and Context

Fixes #25 

## How Has This Been Tested?

Tested using yardstick 0.0.7 on R 4.0.2.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My code follows the [code style](https://style.tidyverse.org/) of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

Note that I did *not* add an example in the docs of `threshold_perf()` that uses the new feature.