### PR TITLE
Implement `event_level` argument for `threshold_perf()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # probably (development version)
 
+* `threshold_perf()` now has an explicit `event_level` argument rather than
+  respecting the now deprecated `yardstick.event_first` global option (#45).
+
 * Bumped the minimum required R version to >=3.4.0 to align with the rest of the
   tidyverse.
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,8 +1,8 @@
 
 # is there a forcats for this?
-recode_data <- function(obs, prob, threshold) {
+recode_data <- function(obs, prob, threshold, event_level) {
   lvl <- levels(obs)
-  if (getOption("yardstick.event_first", default = TRUE)) {
+  if (identical(event_level, "first")) {
     pred <- ifelse(prob >= threshold, lvl[1], lvl[2])
   } else {
     pred <- ifelse(prob >= threshold, lvl[2], lvl[1])

--- a/man/threshold_perf.Rd
+++ b/man/threshold_perf.Rd
@@ -7,7 +7,15 @@
 \usage{
 threshold_perf(.data, ...)
 
-\method{threshold_perf}{data.frame}(.data, truth, estimate, thresholds = NULL, na_rm = TRUE, ...)
+\method{threshold_perf}{data.frame}(
+  .data,
+  truth,
+  estimate,
+  thresholds = NULL,
+  na_rm = TRUE,
+  event_level = "first",
+  ...
+)
 }
 \arguments{
 \item{.data}{A tibble, potentially grouped.}
@@ -26,6 +34,9 @@ of values between 0.5 and 1.0 are used. \strong{Note}: if this
 argument is used, it must be named.}
 
 \item{na_rm}{A single logical: should missing data be removed?}
+
+\item{event_level}{A single string. Either \code{"first"} or \code{"second"} to specify
+which level of \code{truth} to consider as the "event".}
 }
 \value{
 A tibble with columns: \code{.threshold}, \code{.estimator}, \code{.metric},

--- a/tests/testthat/test-threshold-perf.R
+++ b/tests/testthat/test-threshold-perf.R
@@ -29,7 +29,7 @@ thr <- c(0, .5, .78, 1)
 mets <- yardstick::metric_set(sens, spec, j_index)
 
 get_res <- function(prob, obs, cut) {
-  cls <- recode_data(obs, prob, cut)
+  cls <- recode_data(obs, prob, cut, event_level = "first")
   dat <- data.frame(
     obs = obs,
     cls = cls
@@ -61,7 +61,8 @@ test_that('factor from numeric', {
     recode_data(
       obs = ex_data$outcome,
       prob = ex_data$prob_est,
-      threshold = ex_data$prob_est[1]
+      threshold = ex_data$prob_est[1],
+      event_level = "first"
     )
   tab_1 <- table(new_fac_1)
   expect_s3_class(new_fac_1, "factor")
@@ -74,7 +75,8 @@ test_that('factor from numeric', {
     recode_data(
       obs = ex_data_miss$outcome,
       prob = ex_data_miss$prob_est,
-      threshold = ex_data_miss$prob_est[1]
+      threshold = ex_data_miss$prob_est[1],
+      event_level = "first"
     )
   tab_2 <- table(new_fac_2)
   expect_s3_class(new_fac_2, "factor")
@@ -84,22 +86,18 @@ test_that('factor from numeric', {
   expect_equivalent(tab_2["Cl1"], sum(cmpl_probs >= ex_data_miss$prob_est[1]))
   expect_equivalent(tab_2["Cl2"], sum(cmpl_probs <  ex_data_miss$prob_est[1]))
 
-  # reverse factor levels
-  options(yardstick.event_first = FALSE)
-
   new_fac_3 <-
     recode_data(
       obs = ex_data$outcome,
       prob = ex_data$prob_est,
-      threshold = ex_data$prob_est[1]
+      threshold = ex_data$prob_est[1],
+      event_level = "second"
     )
   tab_3 <- table(new_fac_3)
   expect_s3_class(new_fac_3, "factor")
   expect_true(isTRUE(all.equal(levels(new_fac_3), levels(ex_data$outcome))))
   expect_equivalent(tab_3["Cl1"], sum(ex_data$prob_est <  ex_data$prob_est[1]))
   expect_equivalent(tab_3["Cl2"], sum(ex_data$prob_est >= ex_data$prob_est[1]))
-
-  options(yardstick.event_first = TRUE)
 })
 
 test_that('single group', {


### PR DESCRIPTION
Closes #40 

Not adding anything to `make_two_class_pred()`. The docs there are clear that `estimate` maps to the first level supplied in `levels` and I don't see any reason to support `event_level` there.

But `threshold_perf()` does need to support it because it computes metrics internally.

Since probably isn't used that much, and `event_level = "second"` is used even less, I've done a hard break by removing support for `yardstick.event_level` altogether in favor of the explicit `event_level` argument.