### PR TITLE
Adds source_class to cal object, improvements to the print out

### DIFF
--- a/R/cal-estimate-beta.R
+++ b/R/cal-estimate-beta.R
@@ -41,6 +41,7 @@ cal_estimate_beta.data.frame <- function(.data,
     shape_params = shape_params,
     location_params = location_params,
     estimate = {{ estimate }},
+    source_class = cal_class_name(.data),
     ...
   )
 }
@@ -71,6 +72,7 @@ cal_estimate_beta.tune_results <- function(.data,
       estimate = !!tune_args$estimate,
       shape_params = shape_params,
       location_params = location_params,
+      source_class = cal_class_name(.data),
       ...
     )
 }
@@ -83,6 +85,7 @@ cal_beta_impl <- function(.data,
                           shape_params = 2,
                           location_params = 1,
                           estimate = dplyr::starts_with(".pred_"),
+                          source_class = NULL,
                           ...) {
   truth <- enquo(truth)
   estimate <- enquo(estimate)
@@ -106,6 +109,7 @@ cal_beta_impl <- function(.data,
       truth = {{ truth }},
       method = "Beta",
       rows = nrow(.data),
+      source_class = source_class,
       additional_class = "cal_estimate_beta"
     )
   } else {

--- a/R/cal-estimate-isotonic.R
+++ b/R/cal-estimate-isotonic.R
@@ -37,6 +37,7 @@ cal_estimate_isotonic.data.frame <- function(.data,
     .data = .data,
     truth = {{ truth }},
     estimate = {{ estimate }},
+    source_class = cal_class_name(.data),
     ...
   )
 }
@@ -106,6 +107,7 @@ cal_estimate_isotonic_boot.data.frame <- function(.data,
     truth = {{ truth }},
     estimate = {{ estimate }},
     times = times,
+    source_class = cal_class_name(.data),
     ...
   )
 }
@@ -134,6 +136,7 @@ cal_estimate_isotonic_boot.tune_results <- function(.data,
       truth = !!tune_args$truth,
       estimate = !!tune_args$estimate,
       times = times,
+      source_class = cal_class_name(.data),
       ...
     )
 }
@@ -144,6 +147,7 @@ cal_isoreg_impl <- function(.data,
                             estimate,
                             sampled = FALSE,
                             times = 1,
+                            source_class = NULL,
                             ...) {
   truth <- enquo(truth)
   estimate <- enquo(estimate)
@@ -204,6 +208,7 @@ cal_isoreg_impl <- function(.data,
       truth = !!truth,
       method = method,
       rows = nrow(.data),
+      source_class = source_class,
       additional_class = addl_class
     )
   } else {

--- a/R/cal-estimate-logistic.R
+++ b/R/cal-estimate-logistic.R
@@ -53,6 +53,7 @@ cal_estimate_logistic.data.frame <- function(.data,
     truth = {{ truth }},
     estimate = {{ estimate }},
     smooth = smooth,
+    source_class = cal_class_name(.data),
     ...
   )
 }
@@ -81,6 +82,7 @@ cal_estimate_logistic.tune_results <- function(.data,
       truth = !!tune_args$truth,
       estimate = !!tune_args$estimate,
       smooth = smooth,
+      source_class = cal_class_name(.data),
       ...
     )
 }
@@ -91,6 +93,7 @@ cal_logistic_impl <- function(.data,
                               estimate = dplyr::starts_with(".pred_"),
                               type,
                               smooth,
+                              source_class = NULL,
                               ...) {
   if (smooth) {
     model <- "logistic_spline"
@@ -121,7 +124,8 @@ cal_logistic_impl <- function(.data,
       truth = !!truth,
       method = method,
       rows = nrow(.data),
-      additional_class = additional_class
+      additional_class = additional_class,
+      source_class = source_class
     )
   } else {
     stop_multiclass()

--- a/R/cal-estimate-utils.R
+++ b/R/cal-estimate-utils.R
@@ -22,10 +22,10 @@ print_cal_binary <- function(x, upv = FALSE, ...) {
   cli::cli_text("Type: {.val2 Binary}")
   cli::cli_text("Source class: {.val2 {x$source_class}}")
   if(length(x$estimates) == 1) {
-    cli::cli_text("Train set size: {.val2 {rows}}")
+    cli::cli_text("Data points: {.val2 {rows}}")
   } else {
     no_ests <- length(x$estimates)
-    grps <- "Train set size: {.val2 {rows}}, split in {.val2 {no_ests}} groups"
+    grps <- "Data points: {.val2 {rows}}, split in {.val2 {no_ests}} groups"
     cli::cli_text(grps)
   }
 

--- a/tests/testthat/_snaps/cal-estimate.md
+++ b/tests/testthat/_snaps/cal-estimate.md
@@ -7,6 +7,7 @@
       -- Probability Calibration 
       Method: Logistic
       Type: Binary
+      Source class: Data Frame
       Train set size: 1,010
       Truth variable: `Class`
       Estimate variables:
@@ -22,7 +23,8 @@
       -- Probability Calibration 
       Method: Logistic
       Type: Binary
-      Train set size: 4,000
+      Source class: Tune Results
+      Train set size: 4,000, split in 8 groups
       Truth variable: `class`
       Estimate variables:
       `.pred_class_1` ==> class_1
@@ -37,6 +39,7 @@
       -- Probability Calibration 
       Method: Logistic Spline
       Type: Binary
+      Source class: Data Frame
       Train set size: 1,010
       Truth variable: `Class`
       Estimate variables:
@@ -52,7 +55,8 @@
       -- Probability Calibration 
       Method: Logistic Spline
       Type: Binary
-      Train set size: 4,000
+      Source class: Tune Results
+      Train set size: 4,000, split in 8 groups
       Truth variable: `class`
       Estimate variables:
       `.pred_class_1` ==> class_1
@@ -67,6 +71,7 @@
       -- Probability Calibration 
       Method: Isotonic
       Type: Binary
+      Source class: Data Frame
       Train set size: 1,010
       Unique Probability Values: 66
       Truth variable: `Class`
@@ -83,7 +88,8 @@
       -- Probability Calibration 
       Method: Isotonic
       Type: Binary
-      Train set size: 4,000
+      Source class:
+      Train set size: 4,000, split in 8 groups
       Unique Probability Values: 86
       Truth variable: `class`
       Estimate variables:
@@ -99,6 +105,7 @@
       -- Probability Calibration 
       Method: Bootstrapped Isotonic Regression
       Type: Binary
+      Source class: Data Frame
       Train set size: 1,010
       Truth variable: `Class`
       Estimate variables:
@@ -114,6 +121,7 @@
       -- Probability Calibration 
       Method: Beta
       Type: Binary
+      Source class: Data Frame
       Train set size: 1,010
       Truth variable: `Class`
       Estimate variables:
@@ -129,7 +137,8 @@
       -- Probability Calibration 
       Method: Beta
       Type: Binary
-      Train set size: 4,000
+      Source class: Tune Results
+      Train set size: 4,000, split in 8 groups
       Truth variable: `class`
       Estimate variables:
       `.pred_class_1` ==> class_1
@@ -144,6 +153,7 @@
       -- Probability Calibration 
       Method: Isotonic
       Type: Binary
+      Source class: Data Frame
       Train set size: 1,010
       Unique Probability Values: 66
       Truth variable: `Class`

--- a/tests/testthat/_snaps/cal-estimate.md
+++ b/tests/testthat/_snaps/cal-estimate.md
@@ -8,7 +8,7 @@
       Method: Logistic
       Type: Binary
       Source class: Data Frame
-      Train set size: 1,010
+      Data points: 1,010
       Truth variable: `Class`
       Estimate variables:
       `.pred_good` ==> good
@@ -24,7 +24,7 @@
       Method: Logistic
       Type: Binary
       Source class: Tune Results
-      Train set size: 4,000, split in 8 groups
+      Data points: 4,000, split in 8 groups
       Truth variable: `class`
       Estimate variables:
       `.pred_class_1` ==> class_1
@@ -40,7 +40,7 @@
       Method: Logistic Spline
       Type: Binary
       Source class: Data Frame
-      Train set size: 1,010
+      Data points: 1,010
       Truth variable: `Class`
       Estimate variables:
       `.pred_good` ==> good
@@ -56,7 +56,7 @@
       Method: Logistic Spline
       Type: Binary
       Source class: Tune Results
-      Train set size: 4,000, split in 8 groups
+      Data points: 4,000, split in 8 groups
       Truth variable: `class`
       Estimate variables:
       `.pred_class_1` ==> class_1
@@ -72,7 +72,7 @@
       Method: Isotonic
       Type: Binary
       Source class: Data Frame
-      Train set size: 1,010
+      Data points: 1,010
       Unique Probability Values: 66
       Truth variable: `Class`
       Estimate variables:
@@ -89,7 +89,7 @@
       Method: Isotonic
       Type: Binary
       Source class:
-      Train set size: 4,000, split in 8 groups
+      Data points: 4,000, split in 8 groups
       Unique Probability Values: 86
       Truth variable: `class`
       Estimate variables:
@@ -106,7 +106,7 @@
       Method: Bootstrapped Isotonic Regression
       Type: Binary
       Source class: Data Frame
-      Train set size: 1,010
+      Data points: 1,010
       Truth variable: `Class`
       Estimate variables:
       `.pred_good` ==> good
@@ -122,7 +122,7 @@
       Method: Beta
       Type: Binary
       Source class: Data Frame
-      Train set size: 1,010
+      Data points: 1,010
       Truth variable: `Class`
       Estimate variables:
       `.pred_good` ==> good
@@ -138,7 +138,7 @@
       Method: Beta
       Type: Binary
       Source class: Tune Results
-      Train set size: 4,000, split in 8 groups
+      Data points: 4,000, split in 8 groups
       Truth variable: `class`
       Estimate variables:
       `.pred_class_1` ==> class_1
@@ -154,7 +154,7 @@
       Method: Isotonic
       Type: Binary
       Source class: Data Frame
-      Train set size: 1,010
+      Data points: 1,010
       Unique Probability Values: 66
       Truth variable: `Class`
       Estimate variables:


### PR DESCRIPTION
Fixes #61 

```
── Probability Calibration 
Method: Beta
Type: Binary
Source class: Tune Results
Train set size: 3,000, split in 3 groups
Truth variable: `class`
Estimate variables:
`.pred_class_1` ==> class_1
`.pred_class_2` ==> class_2
```