### PR TITLE
better message for estimation functions when the levels are incomplete or incorrect

### DIFF
--- a/R/cal-estimate-beta.R
+++ b/R/cal-estimate-beta.R
@@ -5,11 +5,12 @@
 #' @param location_params Number of location parameters to use. Accepted values
 #' 1 and 0. Defaults to 1.
 #' @inheritParams cal_estimate_logistic
-#' @details  This function uses the `betcal::beta_calibration()` function, and
+#' @details  This function uses the [betacal::beta_calibration()] function, and
 #' retains the resulting model.
 #' @references Meelis Kull, Telmo M. Silva Filho, Peter Flach "Beyond sigmoids:
 #' How to obtain well-calibrated probabilities from binary classifiers with beta
 #' calibration," _Electronic Journal of Statistics_ 11(2), 5052-5080, (2017)
+#' @template multiclass
 #' @examples
 #' # It will automatically identify the probability columns
 #' # if passed a model fitted with tidymodels

--- a/R/cal-estimate-isotonic.R
+++ b/R/cal-estimate-isotonic.R
@@ -2,8 +2,9 @@
 #------------------------------- >> Isotonic  ----------------------------------
 #' Uses an Isotonic regression model to calibrate model predictions.
 #' @inheritParams cal_estimate_logistic
-#' @details This function uses `stats::isoreg()` to create obtain the calibration
+#' @details This function uses [stats::isoreg()] to create obtain the calibration
 #' values for binary classification or numeric regression.
+#' @template multiclass
 #' @references
 #' Zadrozny, Bianca and Elkan, Charles. (2002). Transforming Classifier Scores
 #' into Accurate Multiclass Probability Estimates. _Proceedings of the ACM SIGKDD
@@ -82,9 +83,10 @@ cal_estimate_isotonic.tune_results <- function(.data,
 #' Uses a bootstrapped Isotonic regression model to calibrate probabilities
 #' @param times Number of bootstraps.
 #' @inheritParams cal_estimate_logistic
-#' @details This function uses `stats::isoreg()` to create obtain the calibration
-#' values. It runs `isoreg()` multiple times, and each time with a different
+#' @details This function uses [stats::isoreg()] to create obtain the calibration
+#' values. It runs [stats::isoreg()] multiple times, and each time with a different
 #' seed. The results are saved inside the returned `cal_object`.
+#' @template multiclass
 #' @examples
 #' # It will automatically identify the probability columns
 #' # if passed a model fitted with tidymodels

--- a/R/cal-estimate-linear.R
+++ b/R/cal-estimate-linear.R
@@ -56,8 +56,8 @@
 #' This function uses existing modeling functions from other packages to create
 #' the calibration:
 #'
-#' - `stats::glm()` is used when `smooth` is set to `FALSE`
-#' - `mgcv::gam()` is used when `smooth` is set to `TRUE`
+#' - [stats::glm()] is used when `smooth` is set to `FALSE`
+#' - [mgcv::gam()] is used when `smooth` is set to `TRUE`
 #'
 #' These methods estimate the relationship in the unmodified predicted values
 #' and then remove that trend when [cal_apply()] is invoked.

--- a/R/cal-estimate-logistic.R
+++ b/R/cal-estimate-logistic.R
@@ -20,15 +20,23 @@
 #' # It will automatically identify the probability columns
 #' # if passed a model fitted with tidymodels
 #' cal_estimate_logistic(segment_logistic, Class)
+#'
 #' # Specify the variable names in a vector of unquoted names
 #' cal_estimate_logistic(segment_logistic, Class, c(.pred_poor, .pred_good))
+#'
 #' # dplyr selector functions are also supported
 #' cal_estimate_logistic(segment_logistic, Class, dplyr::starts_with(".pred_"))
 #' @details
 #' This function uses existing modeling functions from other packages to create
 #' the calibration:
-#' - `stats::glm()` is used when `smooth` is set to `FALSE`
-#' - `mgcv::gam()` is used when `smooth` is set to `TRUE`
+#' - [stats::glm()] is used when `smooth` is set to `FALSE`
+#' - [mgcv::gam()] is used when `smooth` is set to `TRUE`
+#'
+#' ## Multiclass Extension
+#'
+#' This method has _not_ been extended to multiclass outcomes. However, the
+#' natural multiclass extension is [cal_estimate_multinomial()].
+#'
 #' @export
 cal_estimate_logistic <- function(.data,
                                   truth = NULL,

--- a/R/cal-estimate-logistic.R
+++ b/R/cal-estimate-logistic.R
@@ -145,7 +145,8 @@ cal_logistic_impl <- function(.data,
     )
   } else {
     msg <- paste("The number of outcome factor levels isn't consistent with",
-                 "the calibration method. The levels were:",
+                 "the calibration method. Only two class `truth` factors are",
+                 "allowed. The given levels were:",
                  paste0("'", levels, "'", collapse = ", "))
     rlang::abort(msg)
   }

--- a/R/cal-estimate-logistic.R
+++ b/R/cal-estimate-logistic.R
@@ -115,7 +115,7 @@ cal_logistic_impl <- function(.data,
 
   truth <- enquo(truth)
 
-  levels <- truth_estimate_map(.data, !!truth, {{ estimate }})
+  levels <- truth_estimate_map(.data, !!truth, {{ estimate }}, validate = TRUE)
 
   if (length(levels) == 2) {
     log_model <- cal_logistic_impl_grp(
@@ -136,7 +136,10 @@ cal_logistic_impl <- function(.data,
       source_class = source_class
     )
   } else {
-    stop_multiclass()
+    msg <- paste("The number of outcome factor levels isn't consistent with",
+                 "the calibration method. The levels were:",
+                 paste0("'", levels, "'", collapse = ", "))
+    rlang::abort(msg)
   }
 
   res

--- a/R/cal-estimate-utils.R
+++ b/R/cal-estimate-utils.R
@@ -178,10 +178,6 @@ as_cal_object <- function(estimate,
   )
 }
 
-stop_multiclass <- function() {
-  cli::cli_abort("Multiclass not supported...yet")
-}
-
 # Wraps tidyselect call to avoid code duplication in the function above
 tidyselect_cols <- function(.data, x) {
   tidyselect::eval_select(

--- a/R/cal-utils.R
+++ b/R/cal-utils.R
@@ -62,7 +62,7 @@ check_level_consistency <- function(lvls, mapping) {
     msg <- paste0(
       "We can't connect the specified prediction columns to some factor levels (",
       missings, "). The selected columns were ", cols, ". Are there more ",
-      "columns to add in the funciton call?"
+      "columns to add in the function call?"
     )
     rlang::abort(msg)
   }

--- a/R/cal-utils.R
+++ b/R/cal-utils.R
@@ -4,7 +4,7 @@
 # named variables, it will map the variables based on the position.
 # It returns a named list, wit the variable names as syms, and the assigned
 # levels as the name.
-truth_estimate_map <- function(.data, truth, estimate) {
+truth_estimate_map <- function(.data, truth, estimate, validate = FALSE) {
   truth_str <- tidyselect_cols(.data, {{ truth }})
 
   if(is.integer(truth_str)) {
@@ -38,11 +38,34 @@ truth_estimate_map <- function(.data, truth, estimate) {
         ~ sym(estimate_str[[.x]])
       )
     }
-
+    if (validate) {
+      check_level_consistency(truth_levels, est_map)
+    }
     res <- set_names(est_map, truth_levels)
   } else {
+    # regression case
     res <- list(sym(estimate_str))
     names(res) <- "predictions"
   }
   purrr::discard(res, is.null)
+}
+
+
+check_level_consistency <- function(lvls, mapping) {
+  null_map <- purrr::map_lgl(mapping, is_null)
+  if (any(null_map) | length(lvls) != length(mapping)) {
+    missings <- lvls[null_map]
+    missings <- paste0(missings, collapse = ", ")
+    cols <- mapping[!null_map]
+    cols < purrr::map_chr(cols, as.character)
+    cols <- paste0(cols, collapse = ", ")
+    msg <- paste0(
+      "We can't connect the specified prediction columns to some factor levels (",
+      missings, "). The selected columns were ", cols, ". Are there more ",
+      "columns to add in the funciton call?"
+    )
+    rlang::abort(msg)
+  }
+  invisible(NULL)
+
 }

--- a/R/cal-validate.R
+++ b/R/cal-validate.R
@@ -23,7 +23,7 @@
 #'
 #' @template metrics_cls
 #'
-#' @param metrics A set of metrics passed created via `yardstick::metric_set()`
+#' @param metrics A set of metrics passed created via [yardstick::metric_set()]
 #' @param summarize Indicates to pass tibble with the metrics averaged, or
 #' if to return the same sampled object but with new columns containing the
 #' calibration y validation list columns.
@@ -672,7 +672,7 @@ type_sum.cal_binary <- function(x, ...) {
 #'
 #' @template metrics_reg
 #'
-#' @param metrics A set of metrics passed created via `yardstick::metric_set()`
+#' @param metrics A set of metrics passed created via [yardstick::metric_set()]
 #' @param summarize Indicates to pass tibble with the metrics averaged, or
 #' if to return the same sampled object but with new columns containing the
 #' calibration y validation list columns.

--- a/man-roxygen/multiclass.R
+++ b/man-roxygen/multiclass.R
@@ -1,0 +1,7 @@
+#' @section Multiclass Extension:
+#'
+#' This method is designed to work with two classes. For multiclass, it creates
+#' a set of "one versus all" calibrations for each class. After they are
+#' applied to the data, the probability estimates are re-normalized to add to
+#' one. This final step might compromise the calibration.
+#'

--- a/man/cal_estimate_beta.Rd
+++ b/man/cal_estimate_beta.Rd
@@ -66,9 +66,18 @@ calculate the new probabilities.}
 Uses a Beta calibration model to calculate new probabilities
 }
 \details{
-This function uses the \code{betcal::beta_calibration()} function, and
+This function uses the \code{\link[betacal:beta_calibration]{betacal::beta_calibration()}} function, and
 retains the resulting model.
 }
+\section{Multiclass Extension}{
+
+
+This method is designed to work with two classes. For multiclass, it creates
+a set of "one versus all" calibrations for each class. After they are
+applied to the data, the probability estimates are re-normalized to add to
+one. This final step might compromise the calibration.
+}
+
 \examples{
 # It will automatically identify the probability columns
 # if passed a model fitted with tidymodels

--- a/man/cal_estimate_isotonic.Rd
+++ b/man/cal_estimate_isotonic.Rd
@@ -54,9 +54,18 @@ calculate the new probabilities.}
 Uses an Isotonic regression model to calibrate model predictions.
 }
 \details{
-This function uses \code{stats::isoreg()} to create obtain the calibration
+This function uses \code{\link[stats:isoreg]{stats::isoreg()}} to create obtain the calibration
 values for binary classification or numeric regression.
 }
+\section{Multiclass Extension}{
+
+
+This method is designed to work with two classes. For multiclass, it creates
+a set of "one versus all" calibrations for each class. After they are
+applied to the data, the probability estimates are re-normalized to add to
+one. This final step might compromise the calibration.
+}
+
 \examples{
 # ------------------------------------------------------------------------------
 # Binary Classification

--- a/man/cal_estimate_isotonic_boot.Rd
+++ b/man/cal_estimate_isotonic_boot.Rd
@@ -59,10 +59,19 @@ calculate the new probabilities.}
 Uses a bootstrapped Isotonic regression model to calibrate probabilities
 }
 \details{
-This function uses \code{stats::isoreg()} to create obtain the calibration
-values. It runs \code{isoreg()} multiple times, and each time with a different
+This function uses \code{\link[stats:isoreg]{stats::isoreg()}} to create obtain the calibration
+values. It runs \code{\link[stats:isoreg]{stats::isoreg()}} multiple times, and each time with a different
 seed. The results are saved inside the returned \code{cal_object}.
 }
+\section{Multiclass Extension}{
+
+
+This method is designed to work with two classes. For multiclass, it creates
+a set of "one versus all" calibrations for each class. After they are
+applied to the data, the probability estimates are re-normalized to add to
+one. This final step might compromise the calibration.
+}
+
 \examples{
 # It will automatically identify the probability columns
 # if passed a model fitted with tidymodels

--- a/man/cal_estimate_linear.Rd
+++ b/man/cal_estimate_linear.Rd
@@ -60,8 +60,8 @@ Uses a linear regression model to calibrate numeric predictions
 This function uses existing modeling functions from other packages to create
 the calibration:
 \itemize{
-\item \code{stats::glm()} is used when \code{smooth} is set to \code{FALSE}
-\item \code{mgcv::gam()} is used when \code{smooth} is set to \code{TRUE}
+\item \code{\link[stats:glm]{stats::glm()}} is used when \code{smooth} is set to \code{FALSE}
+\item \code{\link[mgcv:gam]{mgcv::gam()}} is used when \code{smooth} is set to \code{TRUE}
 }
 
 These methods estimate the relationship in the unmodified predicted values

--- a/man/cal_estimate_logistic.Rd
+++ b/man/cal_estimate_logistic.Rd
@@ -63,16 +63,23 @@ Uses a logistic regression model to calibrate probabilities
 This function uses existing modeling functions from other packages to create
 the calibration:
 \itemize{
-\item \code{stats::glm()} is used when \code{smooth} is set to \code{FALSE}
-\item \code{mgcv::gam()} is used when \code{smooth} is set to \code{TRUE}
+\item \code{\link[stats:glm]{stats::glm()}} is used when \code{smooth} is set to \code{FALSE}
+\item \code{\link[mgcv:gam]{mgcv::gam()}} is used when \code{smooth} is set to \code{TRUE}
+}
+\subsection{Multiclass Extension}{
+
+This method has \emph{not} been extended to multiclass outcomes. However, the
+natural multiclass extension is \code{\link[=cal_estimate_multinomial]{cal_estimate_multinomial()}}.
 }
 }
 \examples{
 # It will automatically identify the probability columns
 # if passed a model fitted with tidymodels
 cal_estimate_logistic(segment_logistic, Class)
+
 # Specify the variable names in a vector of unquoted names
 cal_estimate_logistic(segment_logistic, Class, c(.pred_poor, .pred_good))
+
 # dplyr selector functions are also supported
 cal_estimate_logistic(segment_logistic, Class, dplyr::starts_with(".pred_"))
 }

--- a/man/cal_validate_beta.Rd
+++ b/man/cal_validate_beta.Rd
@@ -49,7 +49,7 @@ defaults to the prefix used by tidymodels (\code{.pred_}). The order of the
 identifiers will be considered the same as the order of the levels of the
 \code{truth} variable.}
 
-\item{metrics}{A set of metrics passed created via \code{yardstick::metric_set()}}
+\item{metrics}{A set of metrics passed created via \code{\link[yardstick:metric_set]{yardstick::metric_set()}}}
 
 \item{summarize}{Indicates to pass tibble with the metrics averaged, or
 if to return the same sampled object but with new columns containing the

--- a/man/cal_validate_isotonic.Rd
+++ b/man/cal_validate_isotonic.Rd
@@ -49,7 +49,7 @@ defaults to the prefix used by tidymodels (\code{.pred_}). The order of the
 identifiers will be considered the same as the order of the levels of the
 \code{truth} variable.}
 
-\item{metrics}{A set of metrics passed created via \code{yardstick::metric_set()}}
+\item{metrics}{A set of metrics passed created via \code{\link[yardstick:metric_set]{yardstick::metric_set()}}}
 
 \item{save_details}{Indicates whether to include the \code{calibration} and
 \code{validation} columns when the \code{summarize} argument is set to FALSE.}

--- a/man/cal_validate_isotonic_boot.Rd
+++ b/man/cal_validate_isotonic_boot.Rd
@@ -49,7 +49,7 @@ defaults to the prefix used by tidymodels (\code{.pred_}). The order of the
 identifiers will be considered the same as the order of the levels of the
 \code{truth} variable.}
 
-\item{metrics}{A set of metrics passed created via \code{yardstick::metric_set()}}
+\item{metrics}{A set of metrics passed created via \code{\link[yardstick:metric_set]{yardstick::metric_set()}}}
 
 \item{save_details}{Indicates whether to include the \code{calibration} and
 \code{validation} columns when the \code{summarize} argument is set to FALSE.}

--- a/man/cal_validate_linear.Rd
+++ b/man/cal_validate_linear.Rd
@@ -49,7 +49,7 @@ defaults to the prefix used by tidymodels (\code{.pred_}). The order of the
 identifiers will be considered the same as the order of the levels of the
 \code{truth} variable.}
 
-\item{metrics}{A set of metrics passed created via \code{yardstick::metric_set()}}
+\item{metrics}{A set of metrics passed created via \code{\link[yardstick:metric_set]{yardstick::metric_set()}}}
 
 \item{save_details}{Indicates whether to include the \code{calibration} and
 \code{validation} columns when the \code{summarize} argument is set to FALSE.}

--- a/man/cal_validate_logistic.Rd
+++ b/man/cal_validate_logistic.Rd
@@ -49,7 +49,7 @@ defaults to the prefix used by tidymodels (\code{.pred_}). The order of the
 identifiers will be considered the same as the order of the levels of the
 \code{truth} variable.}
 
-\item{metrics}{A set of metrics passed created via \code{yardstick::metric_set()}}
+\item{metrics}{A set of metrics passed created via \code{\link[yardstick:metric_set]{yardstick::metric_set()}}}
 
 \item{save_details}{Indicates whether to include the \code{calibration} and
 \code{validation} columns when the \code{summarize} argument is set to FALSE.}

--- a/man/cal_validate_multinomial.Rd
+++ b/man/cal_validate_multinomial.Rd
@@ -49,7 +49,7 @@ defaults to the prefix used by tidymodels (\code{.pred_}). The order of the
 identifiers will be considered the same as the order of the levels of the
 \code{truth} variable.}
 
-\item{metrics}{A set of metrics passed created via \code{yardstick::metric_set()}}
+\item{metrics}{A set of metrics passed created via \code{\link[yardstick:metric_set]{yardstick::metric_set()}}}
 
 \item{save_details}{Indicates whether to include the \code{calibration} and
 \code{validation} columns when the \code{summarize} argument is set to FALSE.}

--- a/tests/testthat/_snaps/cal-estimate.md
+++ b/tests/testthat/_snaps/cal-estimate.md
@@ -16,11 +16,11 @@
 
 ---
 
-    We can't connect the specified prediction columns to some factor levels (good). The selected columns were .pred_poor. Are there more columns to add in the funciton call?
+    We can't connect the specified prediction columns to some factor levels (good). The selected columns were .pred_poor. Are there more columns to add in the function call?
 
 ---
 
-    The number of outcome factor levels isn't consistent with the calibration method. The levels were: 'VF', 'F', 'M', 'L'
+    The number of outcome factor levels isn't consistent with the calibration method. Only two class `truth` factors are allowed. The given levels were: 'VF', 'F', 'M', 'L'
 
 # Logistic estimates work - tune_results
 

--- a/tests/testthat/_snaps/cal-estimate.md
+++ b/tests/testthat/_snaps/cal-estimate.md
@@ -14,6 +14,14 @@
       `.pred_good` ==> good
       `.pred_poor` ==> poor
 
+---
+
+    We can't connect the specified prediction columns to some factor levels (good). The selected columns were .pred_poor. Are there more columns to add in the funciton call?
+
+---
+
+    The number of outcome factor levels isn't consistent with the calibration method. The levels were: 'VF', 'F', 'M', 'L'
+
 # Logistic estimates work - tune_results
 
     Code

--- a/tests/testthat/test-cal-estimate.R
+++ b/tests/testthat/test-cal-estimate.R
@@ -6,6 +6,16 @@ test_that("Logistic estimates work - data.frame", {
   expect_cal_estimate(sl_logistic, "butchered_glm")
   expect_cal_rows(sl_logistic)
   expect_snapshot(print(sl_logistic))
+
+  expect_snapshot_error(
+    segment_logistic %>% cal_estimate_logistic(truth = Class, estimate = .pred_poor)
+  )
+
+  data(hpc_cv, package = "yardstick")
+  expect_snapshot_error(
+    hpc_cv %>% cal_estimate_logistic(truth = obs, estimate = c(VF:L))
+  )
+
 })
 
 test_that("Logistic estimates work - tune_results", {


### PR DESCRIPTION
Closes #94 

Different error messages: 

``` r
library(tidymodels)
library(probably)
#> 
#> Attaching package: 'probably'
#> The following objects are masked from 'package:base':
#> 
#>     as.factor, as.ordered
```

``` r

tidymodels_prefer()
theme_set(theme_bw())
options(pillar.advice = FALSE, pillar.min_title_chars = Inf)
```

``` r

# Previously, these both gave errors of '! Multiclass not supported...yet'

# The estimate function didn't specify all prediction columns: 
segment_logistic %>% cal_estimate_logistic(truth = Class, estimate = .pred_poor)
#> Error in `check_level_consistency()`:
#> ! We can't connect the specified prediction columns to some factor levels (good). The selected columns were .pred_poor. Are there more columns to add in the funciton call?
#> Backtrace:
#>     ▆
#>  1. ├─segment_logistic %>% ...
#>  2. ├─probably::cal_estimate_logistic(., truth = Class, estimate = .pred_poor)
#>  3. └─probably:::cal_estimate_logistic.data.frame(...)
#>  4.   └─probably:::cal_logistic_impl(...)
#>  5.     └─probably:::truth_estimate_map(...)
#>  6.       └─probably:::check_level_consistency(truth_levels, est_map)
#>  7.         └─rlang::abort(msg)

# (Incomplete specification of the columns _does_ work with the plot funcitons tho)

# Added better error for logistic with 3+ classes
hpc_cv %>% cal_estimate_logistic(truth = obs, estimate = c(VF:L))
#> Error in `cal_logistic_impl()`:
#> ! The number of outcome factor levels isn't consistent with the calibration method. The levels were: 'VF', 'F', 'M', 'L'
#> Backtrace:
#>     ▆
#>  1. ├─hpc_cv %>% ...
#>  2. ├─probably::cal_estimate_logistic(., truth = obs, estimate = c(VF:L))
#>  3. └─probably:::cal_estimate_logistic.data.frame(., truth = obs, estimate = c(VF:L))
#>  4.   └─probably:::cal_logistic_impl(...)
#>  5.     └─rlang::abort(msg)
```

<sup>Created on 2023-05-05 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

I've also updated the docs to say when we extend binary methods to multiclass. 