### PR TITLE
better documentation and a new column from CV+ intervals

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # probably (development version)
 
+* `predict.int_conformal_infer_cv()` now returns a `.pred` column that is the average prediction from the resampled models. The prediction intervals are centered on these. 
+
 # probably 1.0.0
 
 * Copyright holder changed to Posit Software PBC.

--- a/R/conformal_infer.R
+++ b/R/conformal_infer.R
@@ -122,8 +122,18 @@ print.int_conformal_infer <- function(x, ...) {
 #' @param level The confidence level for the intervals.
 #' @param ... Not currently used.
 #' @return A tibble with columns `.pred_lower` and `.pred_upper`. If
-#' the computations for the prediction bound fail, a missing value is used.
+#' the computations for the prediction bound fail, a missing value is used. For
+#' objects produced by [int_conformal_infer_cv()], an additional `.pred` column
+#' is  also returned (see Details below).
 #' @seealso [int_conformal_infer()], [int_conformal_infer_cv()]
+#' @details
+#' For the CV+. estimator produced by [int_conformal_infer_cv()], the intervals
+#' are centered around the mean of the predictions produced by the
+#' resample-specific model. For example, with 10-fold cross-validation, `.pred`
+#' is the average of the predictions from the 10 models produced by each fold.
+#' This may differ from the prediction generated from a model fit that was
+#' trained on the entire training set, especially if the training sets are
+#' small.
 #' @export
 predict.int_conformal_infer <- function(object, new_data, level = 0.95, ...) {
   check_data(new_data, object$wflow)

--- a/R/conformal_infer_cv.R
+++ b/R/conformal_infer_cv.R
@@ -133,7 +133,7 @@ predict.int_conformal_infer_cv <- function(object, new_data, level = 0.95, ...) 
       as.list(seq_along(mean_pred)),
       ~ .get_upper_cv_bound(mean_pred[.x], object$abs_resid, level = level)
     )
-  dplyr::tibble(.pred_lower = lower, .pred_upper = upper)
+  dplyr::tibble(.pred_lower = lower, .pred = mean_pred, .pred_upper = upper)
 }
 
 #' @export

--- a/man/predict.int_conformal_infer.Rd
+++ b/man/predict.int_conformal_infer.Rd
@@ -20,10 +20,21 @@
 }
 \value{
 A tibble with columns \code{.pred_lower} and \code{.pred_upper}. If
-the computations for the prediction bound fail, a missing value is used.
+the computations for the prediction bound fail, a missing value is used. For
+objects produced by \code{\link[=int_conformal_infer_cv]{int_conformal_infer_cv()}}, an additional \code{.pred} column
+is  also returned (see Details below).
 }
 \description{
 Prediction intervals from conformal methods
+}
+\details{
+For the CV+. estimator produced by \code{\link[=int_conformal_infer_cv]{int_conformal_infer_cv()}}, the intervals
+are centered around the mean of the predictions produced by the
+resample-specific model. For example, with 10-fold cross-validation, \code{.pred}
+is the average of the predictions from the 10 models produced by each fold.
+This may differ from the prediction generated from a model fit that was
+trained on the entire training set, especially if the training sets are
+small.
 }
 \seealso{
 \code{\link[=int_conformal_infer]{int_conformal_infer()}}, \code{\link[=int_conformal_infer_cv]{int_conformal_infer_cv()}}

--- a/tests/testthat/test-conformal-intervals.R
+++ b/tests/testthat/test-conformal-intervals.R
@@ -198,7 +198,7 @@ test_that("conformal intervals", {
   cv_int <- int_conformal_infer_cv(cv_res)
   cv_bounds <- predict(cv_int, sim_small)
   cv_bounds_90 <- predict(cv_int, sim_small, level = .9)
-  expect_equal(names(cv_bounds), c(".pred_lower", ".pred_upper"))
+  expect_equal(names(cv_bounds), c(".pred_lower", ".pred", ".pred_upper"))
   expect_equal(nrow(cv_bounds), nrow(sim_small))
   expect_true(mean(complete.cases(cv_bounds)) == 1)
   expect_true(
@@ -212,7 +212,7 @@ test_that("conformal intervals", {
   grid_int <- int_conformal_infer_cv(grid_res, two_models[1,])
   grid_bounds <- predict(grid_int, sim_small)
   grid_bounds_90 <- predict(grid_int, sim_small, level = .9)
-  expect_equal(names(grid_bounds), c(".pred_lower", ".pred_upper"))
+  expect_equal(names(grid_bounds), c(".pred_lower", ".pred", ".pred_upper"))
   expect_equal(nrow(grid_bounds), nrow(sim_small))
   expect_true(mean(complete.cases(grid_bounds)) == 1)
   expect_true(


### PR DESCRIPTION
In some cases, the model fits can be really different: 

![image](https://github.com/tidymodels/probably/assets/5731043/6be8d4d2-32b5-4d37-a8f5-0b0a7fd4bd69)

Added documentation and a new `.pred` column. 