### PR TITLE
Remove unused create_filter_expr function

### DIFF
--- a/R/cal-estimate-utils.R
+++ b/R/cal-estimate-utils.R
@@ -211,11 +211,6 @@ split_dplyr_groups <- function(.data) {
   res
 }
 
-create_filter_expr <- function(...) {
-  purrr::imap(..., ~ expr(!!parse_expr(.y) == !!.x)) %>%
-    purrr::reduce(function(x, y) expr(!!x & !!y))
-}
-
 stop_null_parameters <- function(x) {
   if (!is.null(x)) {
     rlang::abort("The `parameters` argument is only valid for `tune_results`.")


### PR DESCRIPTION
This commit removes the unused helper function create_filter_expr from probably/R/cal-estimate-utils.R. The function became obsolete after a partial revert in #135.

Fixes #139