### PR TITLE
Fix inconsistent appearance of distance metric in `threshold_perf()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 * Fixed an error in `int_conformal_cv()` when grouped resampling was used (#141). 
 
-* Fixed an issue where the `distance` metric appeared inconsistently when using `threshold_perf()` with custom metric sets (#149).
+* Fixed an issue where the `distance` metric appeared inconsistently when using `threshold_perf()` with custom metric sets (@jrwinget, #149).
 
 # probably 1.0.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 
 * Fixed an error in `int_conformal_cv()` when grouped resampling was used (#141). 
 
+* Fixed an issue where the `distance` metric appeared inconsistently when using `threshold_perf()` with custom metric sets (#149).
 
 # probably 1.0.3
 

--- a/R/threshold_perf.R
+++ b/R/threshold_perf.R
@@ -199,11 +199,11 @@ threshold_perf.data.frame <- function(.data,
     # Create the `distance` metric data frame
     # and add it on
     sens_vec <- .data_metrics %>%
-      dplyr::filter(.metric == "sens") %>%
+      dplyr::filter(.metric == "sensitivity") %>%
       dplyr::pull(.estimate)
 
     dist <- .data_metrics %>%
-      dplyr::filter(.metric == "spec") %>%
+      dplyr::filter(.metric == "specificity") %>%
       dplyr::mutate(
         .metric = "distance",
         # .estimate is specificity currently. This recodes as distance
@@ -232,7 +232,9 @@ expand_preds <- function(.data, threshold, inc = NULL) {
 check_thresholded_metrics <- function(x) {
   y <- dplyr::as_tibble(x)
   if (!all(y$class == "class_metric")) {
-    rlang::abort("All metrics must be of type 'class_metric' (e.g. `sensitivity()`, ect)")
+    rlang::abort(
+      "All metrics must be of type 'class_metric' (e.g. `sensitivity()`, ect)"
+    )
   }
   # check to see if sensitivity and specificity are in the lists
   has_sens <-

--- a/tests/testthat/_snaps/threshold-perf.md
+++ b/tests/testthat/_snaps/threshold-perf.md
@@ -9,13 +9,13 @@
         dplyr::count(.metric)
     Output
       # A tibble: 5 x 2
-        .metric      n
-        <chr>    <int>
-      1 accuracy    21
-      2 distance    21
-      3 mcc         21
-      4 sens        21
-      5 spec        21
+        .metric         n
+        <chr>       <int>
+      1 accuracy       21
+      2 distance       21
+      3 mcc            21
+      4 sensitivity    21
+      5 specificity    21
 
 ---
 

--- a/tests/testthat/test-threshold-perf.R
+++ b/tests/testthat/test-threshold-perf.R
@@ -32,11 +32,11 @@ get_res <- function(prob, obs, cut) {
 
   # Create the `distance` metric data frame
   sens_vec <- .data_metrics %>%
-    dplyr::filter(.metric == "sens") %>%
+    dplyr::filter(.metric == "sensitivity") %>%
     dplyr::pull(.estimate)
 
   dist <- .data_metrics %>%
-    dplyr::filter(.metric == "spec") %>%
+    dplyr::filter(.metric == "specificity") %>%
     dplyr::mutate(
       .metric = "distance",
       # .estimate is spec currently
@@ -123,8 +123,8 @@ test_that("custom metrics", {
   suppressPackageStartupMessages(require(yardstick))
   suppressPackageStartupMessages(require(dplyr))
 
-  cls_met_bad <- metric_set(sens, spec, accuracy, roc_auc)
-  cls_met_good <- metric_set(sens, spec, accuracy, mcc)
+  cls_met_bad <- metric_set(sensitivity, specificity, accuracy, roc_auc)
+  cls_met_good <- metric_set(sensitivity, specificity, accuracy, mcc)
   cls_met_other <- metric_set(accuracy, mcc)
 
   expect_snapshot_error(


### PR DESCRIPTION
Fixes #149 - Updated `threshold_perf()` to use the correct metric names ("sensitivity" and "specificity") instead of the outdated names ("sens" and "spec").