### PR TITLE
updates for no-suggests checks 

### DIFF
--- a/.github/workflows/R-CMD-check-hard.yaml
+++ b/.github/workflows/R-CMD-check-hard.yaml
@@ -1,0 +1,59 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+#
+# NOTE: This workflow only directly installs "hard" dependencies, i.e. Depends,
+# Imports, and LinkingTo dependencies. Notably, Suggests dependencies are never
+# installed, with the exception of testthat, knitr, and rmarkdown. The cache is
+# never used to avoid accidentally restoring a cache containing a suggested
+# dependency.
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+name: R-CMD-check-hard.yaml
+
+permissions: read-all
+
+jobs:
+  check-no-suggests:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: ubuntu-latest,   r: 'release'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          dependencies: '"hard"'
+          cache: false
+          extra-packages: |
+            any::rcmdcheck
+            any::testthat
+            any::knitr
+            any::rmarkdown
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/R/cal-estimate-beta.R
+++ b/R/cal-estimate-beta.R
@@ -15,9 +15,11 @@
 #' \url{https://www.tidymodels.org/learn/models/calibration/},
 #' [cal_validate_beta()]
 #' @examples
-#' # It will automatically identify the probability columns
-#' # if passed a model fitted with tidymodels
-#' cal_estimate_beta(segment_logistic, Class)
+#' if (rlang::is_installed("betacal")) {
+#'  # It will automatically identify the probability columns
+#'   # if passed a model fitted with tidymodels
+#'   cal_estimate_beta(segment_logistic, Class)
+#' }
 #' @export
 cal_estimate_beta <- function(.data,
                               truth = NULL,

--- a/R/cal-validate.R
+++ b/R/cal-validate.R
@@ -297,10 +297,11 @@ cal_validate_isotonic_boot.tune_results <- function(.data,
 #'
 #' library(dplyr)
 #'
-#' segment_logistic %>%
-#'   rsample::vfold_cv() %>%
-#'   cal_validate_beta(Class)
-#'
+#' if (rlang::is_installed("betacal")) {
+#'   segment_logistic %>%
+#'     rsample::vfold_cv() %>%
+#'     cal_validate_beta(Class)
+#' }
 #' @export
 cal_validate_beta <- function(.data,
                               truth = NULL,

--- a/R/conformal_infer_cv.R
+++ b/R/conformal_infer_cv.R
@@ -33,7 +33,7 @@
 #' Rina Foygel Barber, Emmanuel J. Candès, Aaditya Ramdas, Ryan J. Tibshirani
 #' "Predictive inference with the jackknife+," _The Annals of Statistics_,
 #' 49(1), 486-507, 2021
-#' @examplesIf !probably:::is_cran_check()
+#' @examplesIf !probably:::is_cran_check() & rlang::is_installed(c("modeldata", "parsnip"))
 #' library(workflows)
 #' library(dplyr)
 #' library(parsnip)

--- a/R/conformal_infer_quantile.R
+++ b/R/conformal_infer_quantile.R
@@ -31,7 +31,7 @@
 #' @references
 #' Romano, Yaniv, Evan Patterson, and Emmanuel Candes. "Conformalized quantile
 #' regression." _Advances in neural information processing systems_ 32 (2019).
-#' @examplesIf !probably:::is_cran_check()
+#' @examplesIf !probably:::is_cran_check() & rlang::is_installed(c("modeldata", "parsnip", "quantregForest"))
 #' library(workflows)
 #' library(dplyr)
 #' library(parsnip)

--- a/R/conformal_infer_split.R
+++ b/R/conformal_infer_split.R
@@ -28,7 +28,7 @@
 #' @references
 #' Lei, Jing, et al. "Distribution-free predictive inference for regression."
 #' _Journal of the American Statistical Association_ 113.523 (2018): 1094-1111.
-#' @examplesIf !probably:::is_cran_check()
+#' @examplesIf !probably:::is_cran_check() & rlang::is_installed(c("modeldata", "parsnip", "nnet"))
 #' library(workflows)
 #' library(dplyr)
 #' library(parsnip)

--- a/man/cal_estimate_beta.Rd
+++ b/man/cal_estimate_beta.Rd
@@ -95,9 +95,11 @@ one. This final step might compromise the calibration.
 }
 
 \examples{
-# It will automatically identify the probability columns
-# if passed a model fitted with tidymodels
-cal_estimate_beta(segment_logistic, Class)
+if (rlang::is_installed("betacal")) {
+ # It will automatically identify the probability columns
+  # if passed a model fitted with tidymodels
+  cal_estimate_beta(segment_logistic, Class)
+}
 }
 \references{
 Meelis Kull, Telmo M. Silva Filho, Peter Flach "Beyond sigmoids:

--- a/man/cal_validate_beta.Rd
+++ b/man/cal_validate_beta.Rd
@@ -104,10 +104,11 @@ average of the metrics before, and after the calibration.
 
 library(dplyr)
 
-segment_logistic \%>\%
-  rsample::vfold_cv() \%>\%
-  cal_validate_beta(Class)
-
+if (rlang::is_installed("betacal")) {
+  segment_logistic \%>\%
+    rsample::vfold_cv() \%>\%
+    cal_validate_beta(Class)
+}
 }
 \seealso{
 \url{https://www.tidymodels.org/learn/models/calibration/},

--- a/man/int_conformal_cv.Rd
+++ b/man/int_conformal_cv.Rd
@@ -51,7 +51,7 @@ stop the computations for other types of resamples, but we have no way of
 knowing whether the results are appropriate.
 }
 \examples{
-\dontshow{if (!probably:::is_cran_check()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (!probably:::is_cran_check() & rlang::is_installed(c("modeldata", "parsnip"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(workflows)
 library(dplyr)
 library(parsnip)

--- a/man/int_conformal_quantile.Rd
+++ b/man/int_conformal_quantile.Rd
@@ -46,7 +46,7 @@ Note that the because of the method used to construct the interval, it is
 possible that the prediction intervals will not include the predicted value.
 }
 \examples{
-\dontshow{if (!probably:::is_cran_check()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (!probably:::is_cran_check() & rlang::is_installed(c("modeldata", "parsnip", "quantregForest"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(workflows)
 library(dplyr)
 library(parsnip)

--- a/man/int_conformal_split.Rd
+++ b/man/int_conformal_split.Rd
@@ -45,7 +45,7 @@ quantile (e.g., the 95th for 95\% interval) and should not include rows that
 were in the original training set.
 }
 \examples{
-\dontshow{if (!probably:::is_cran_check()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (!probably:::is_cran_check() & rlang::is_installed(c("modeldata", "parsnip", "nnet"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(workflows)
 library(dplyr)
 library(parsnip)

--- a/tests/testthat/_snaps/cal-estimate.md
+++ b/tests/testthat/_snaps/cal-estimate.md
@@ -213,7 +213,7 @@
       Type: Regression
       Source class: Data Frame
       Data points: 2,000
-      Unique Predicted Values: 43
+      Unique Predicted Values: 40
       Truth variable: `outcome`
       Estimate variables:
       `.pred` ==> predictions
@@ -229,7 +229,7 @@
       Type: Regression
       Source class: Data Frame
       Data points: 2,000, split in 10 groups
-      Unique Predicted Values: 11
+      Unique Predicted Values: 16
       Truth variable: `outcome`
       Estimate variables:
       `.pred` ==> predictions
@@ -373,7 +373,7 @@
 ---
 
     Code
-      print(mtnl_isotonic)
+      print(mtnl_beta)
     Message
       
       -- Probability Calibration 

--- a/tests/testthat/test-cal-apply.R
+++ b/tests/testthat/test-cal-apply.R
@@ -8,6 +8,8 @@ test_that("Logistic apply works - data.frame", {
 })
 
 test_that("Logistic apply works - tune_results", {
+  skip_if_not_installed("modeldata")
+
   tct <- testthat_cal_binary()
   tl_logistic <- cal_estimate_logistic(tct, smooth = FALSE)
   tap_logistic <- cal_apply(tct, tl_logistic)
@@ -27,6 +29,8 @@ test_that("Logistic spline apply works", {
 })
 
 test_that("Logistic spline apply works - tune_results", {
+  skip_if_not_installed("modeldata")
+
   tct <- testthat_cal_binary()
   tl_gam <- cal_estimate_logistic(tct)
   tap_gam <- cal_apply(tct, tl_gam)
@@ -90,6 +94,8 @@ test_that("Isotonic apply works - data.frame", {
 })
 
 test_that("Isotonic apply works - tune_results", {
+  skip_if_not_installed("modeldata")
+
   tct <- testthat_cal_binary()
   tl_isotonic <- cal_estimate_isotonic(tct)
   tap_isotonic <- cal_apply(tct, tl_isotonic)
@@ -107,6 +113,8 @@ test_that("Isotonic Bootstrapped apply works - data.frame", {
 })
 
 test_that("Isotonic Bootstrapped apply works - tune_results", {
+  skip_if_not_installed("modeldata")
+
   tct <- testthat_cal_binary()
   tl_boot <- cal_estimate_isotonic_boot(tct)
   tap_boot <- cal_apply(tct, tl_boot)
@@ -119,6 +127,7 @@ test_that("Isotonic Bootstrapped apply works - tune_results", {
 # ------------------------------------------------------------------------------
 
 test_that("Beta apply works - data.frame", {
+  skip_if_not_installed("betacal")
   sl_beta <- cal_estimate_beta(segment_logistic, Class)
   ap_beta <- cal_apply(segment_logistic, sl_beta)
 
@@ -128,6 +137,9 @@ test_that("Beta apply works - data.frame", {
 })
 
 test_that("Beta apply works - tune_results", {
+  skip_if_not_installed("betacal")
+  skip_if_not_installed("modeldata")
+
   tct <- testthat_cal_binary()
   tl_beta <- cal_estimate_beta(tct)
   tap_beta <- cal_apply(tct, tl_beta)
@@ -148,12 +160,16 @@ test_that("Passing the data frame first returns expected abort message", {
 })
 
 test_that("Passing a tune_results without saved predictions causes error", {
+  skip_if_not_installed("betacal")
+  skip_if_not_installed("modeldata")
+
   tct <- testthat_cal_binary()
   tl_beta <- cal_estimate_beta(tct)
   expect_error(cal_apply(tune::ames_grid_search, tl_beta))
 })
 
 test_that("Passing a calibration object as the first arg fails", {
+  skip_if_not_installed("betacal")
   sl_beta <- cal_estimate_beta(segment_logistic, Class)
   expect_error(cal_apply(sl_beta, segment_logistic))
 })

--- a/tests/testthat/test-cal-estimate.R
+++ b/tests/testthat/test-cal-estimate.R
@@ -1,5 +1,7 @@
 # --------------------------------- Logistic -----------------------------------
 test_that("Logistic estimates work - data.frame", {
+  skip_if_not_installed("modeldata")
+
   sl_logistic <- cal_estimate_logistic(segment_logistic, Class, smooth = FALSE)
   expect_cal_type(sl_logistic, "binary")
   expect_cal_method(sl_logistic, "Logistic regression")
@@ -120,6 +122,8 @@ test_that("Logistic spline estimates work - tune_results", {
 
 # --------------------------------- Isotonic -----------------------------------
 test_that("Isotonic estimates work - data.frame", {
+  skip_if_not_installed("modeldata")
+
   set.seed(100)
   sl_isotonic <- cal_estimate_isotonic(segment_logistic, Class)
   expect_cal_type(sl_isotonic, "binary")
@@ -195,12 +199,16 @@ test_that("Isotonic estimates errors - grouped_df", {
 })
 
 test_that("Isotonic linear estimates work - data.frame", {
+  skip_if_not_installed("modeldata")
+
+  set.seed(2983)
   sl_logistic <- cal_estimate_isotonic(boosting_predictions_oob, outcome, estimate = .pred)
   expect_cal_type(sl_logistic, "regression")
   expect_cal_method(sl_logistic, "Isotonic regression")
   expect_cal_rows(sl_logistic, 2000)
   expect_snapshot(print(sl_logistic))
 
+  set.seed(38)
   sl_logistic_group <- boosting_predictions_oob %>%
     cal_estimate_isotonic(outcome, estimate = .pred, .by = id)
 
@@ -223,6 +231,8 @@ test_that("Isotonic linear estimates work - data.frame", {
 
 # -------------------------- Isotonic Bootstrapped -----------------------------
 test_that("Isotonic Bootstrapped estimates work - data.frame", {
+  skip_if_not_installed("modeldata")
+
   set.seed(1)
   sl_boot <- cal_estimate_isotonic_boot(segment_logistic, Class)
   expect_cal_type(sl_boot, "binary")
@@ -456,6 +466,8 @@ test_that("Passing a binary outcome causes error", {
 
 # --------------------------------- Linear -----------------------------------
 test_that("Linear estimates work - data.frame", {
+  skip_if_not_installed("modeldata")
+
   sl_logistic <- cal_estimate_linear(boosting_predictions_oob, outcome, smooth = FALSE)
   expect_cal_type(sl_logistic, "regression")
   expect_cal_method(sl_logistic, "Linear")

--- a/tests/testthat/test-cal-estimate.R
+++ b/tests/testthat/test-cal-estimate.R
@@ -51,6 +51,8 @@ test_that("Logistic estimates work - data.frame", {
 })
 
 test_that("Logistic estimates work - tune_results", {
+  skip_if_not_installed("modeldata")
+
   tl_logistic <- cal_estimate_logistic(testthat_cal_binary(), smooth = FALSE)
   expect_cal_type(tl_logistic, "binary")
   expect_cal_method(tl_logistic, "Logistic regression")
@@ -101,6 +103,8 @@ test_that("Logistic spline estimates work - data.frame", {
 })
 
 test_that("Logistic spline estimates work - tune_results", {
+  skip_if_not_installed("modeldata")
+
   tl_gam <- cal_estimate_logistic(testthat_cal_binary())
   expect_cal_type(tl_gam, "binary")
   expect_cal_method(tl_gam, "Generalized additive model")
@@ -154,6 +158,8 @@ test_that("Isotonic estimates work - data.frame", {
 })
 
 test_that("Isotonic estimates work - tune_results", {
+  skip_if_not_installed("modeldata")
+
   set.seed(100)
   tl_isotonic <- cal_estimate_isotonic(testthat_cal_binary())
   expect_cal_type(tl_isotonic, "binary")
@@ -250,6 +256,8 @@ test_that("Isotonic Bootstrapped estimates work - data.frame", {
 })
 
 test_that("Isotonic Bootstrapped estimates work - tune_results", {
+  skip_if_not_installed("modeldata")
+
   set.seed(100)
   tl_isotonic <- cal_estimate_isotonic_boot(testthat_cal_binary())
   expect_cal_type(tl_isotonic, "binary")
@@ -286,6 +294,7 @@ test_that("Isotonic Bootstrapped estimates errors - grouped_df", {
 
 # ----------------------------------- Beta -------------------------------------
 test_that("Beta estimates work - data.frame", {
+  skip_if_not_installed("betacal")
   sl_beta <- cal_estimate_beta(segment_logistic, Class, smooth = FALSE)
   expect_cal_type(sl_beta, "binary")
   expect_cal_method(sl_beta, "Beta calibration")
@@ -319,6 +328,9 @@ test_that("Beta estimates work - data.frame", {
 })
 
 test_that("Beta estimates work - tune_results", {
+  skip_if_not_installed("betacal")
+  skip_if_not_installed("modeldata")
+
   tl_beta <- cal_estimate_beta(testthat_cal_binary())
   expect_cal_type(tl_beta, "binary")
   expect_cal_method(tl_beta, "Beta calibration")
@@ -335,20 +347,21 @@ test_that("Beta estimates work - tune_results", {
 
   set.seed(100)
   suppressWarnings(
-    mtnl_isotonic <- cal_estimate_beta(testthat_cal_multiclass())
+    mtnl_beta <- cal_estimate_beta(testthat_cal_multiclass())
   )
-  expect_cal_type(mtnl_isotonic, "one_vs_all")
-  expect_cal_method(mtnl_isotonic, "Beta calibration")
-  expect_snapshot(print(mtnl_isotonic))
-  expect_true(are_groups_configs(mtnl_isotonic))
+  expect_cal_type(mtnl_beta, "one_vs_all")
+  expect_cal_method(mtnl_beta, "Beta calibration")
+  expect_snapshot(print(mtnl_beta))
+  expect_true(are_groups_configs(mtnl_beta))
 
   expect_equal(
     testthat_cal_multiclass_count(),
-    nrow(cal_apply(testthat_cal_multiclass(), mtnl_isotonic))
+    nrow(cal_apply(testthat_cal_multiclass(), mtnl_beta))
   )
 })
 
 test_that("Beta estimates errors - grouped_df", {
+  skip_if_not_installed("betacal")
   expect_snapshot_error(
     cal_estimate_beta(dplyr::group_by(mtcars, vs))
   )
@@ -356,6 +369,9 @@ test_that("Beta estimates errors - grouped_df", {
 
 # ------------------------------ Multinomial -----------------------------------
 test_that("Multinomial estimates work - data.frame", {
+  skip_if_not_installed("modeldata")
+  skip_if_not_installed("nnet")
+
   sp_multi <- cal_estimate_multinomial(species_probs, Species, smooth = FALSE)
   expect_cal_type(sp_multi, "multiclass")
   expect_cal_method(sp_multi, "Multinomial regression")
@@ -390,6 +406,9 @@ test_that("Multinomial estimates work - data.frame", {
 })
 
 test_that("Multinomial estimates work - tune_results", {
+  skip_if_not_installed("modeldata")
+  skip_if_not_installed("nnet")
+
   tl_multi <- cal_estimate_multinomial(testthat_cal_multiclass(), smooth = FALSE)
   expect_cal_type(tl_multi, "multiclass")
   expect_cal_method(tl_multi, "Multinomial regression")
@@ -421,6 +440,9 @@ test_that("Multinomial estimates work - tune_results", {
 })
 
 test_that("Multinomial estimates errors - grouped_df", {
+  skip_if_not_installed("modeldata")
+  skip_if_not_installed("nnet")
+
   expect_snapshot_error(
     cal_estimate_multinomial(dplyr::group_by(mtcars, vs))
   )

--- a/tests/testthat/test-cal-estimate.R
+++ b/tests/testthat/test-cal-estimate.R
@@ -515,6 +515,8 @@ test_that("Linear estimates errors - grouped_df", {
 
 # ----------------------------- Linear Spline --------------------------------
 test_that("Linear spline estimates work - data.frame", {
+  skip_if_not_installed("modeldata")
+
   sl_gam <- cal_estimate_linear(boosting_predictions_oob, outcome)
   expect_cal_type(sl_gam, "regression")
   expect_cal_method(sl_gam, "Generalized additive model")
@@ -561,6 +563,8 @@ test_that("Linear spline estimates work - tune_results", {
 
 # ----------------------------------- Other ------------------------------------
 test_that("Non-default names used for estimate columns", {
+  skip_if_not_installed("modeldata")
+
   new_segment <- segment_logistic
   colnames(new_segment) <- c("poor", "good", "Class")
 

--- a/tests/testthat/test-cal-plot.R
+++ b/tests/testthat/test-cal-plot.R
@@ -279,6 +279,8 @@ test_that("logistic plot function errors - grouped_df", {
 })
 
 test_that("Binary windowed functions work", {
+  skip_if_not_installed("modeldata")
+
   x30 <- .cal_table_windowed(
     segment_logistic,
     truth = Class,

--- a/tests/testthat/test-cal-plot.R
+++ b/tests/testthat/test-cal-plot.R
@@ -72,6 +72,8 @@ test_that("Binary breaks functions work with group argument", {
 })
 
 test_that("Multi-class breaks functions work", {
+  skip_if_not_installed("modeldata")
+
   x10 <- .cal_table_breaks(species_probs, Species, dplyr::starts_with(".pred"))
 
   expect_equal(
@@ -123,6 +125,8 @@ test_that("breaks plot function errors - grouped_df", {
 })
 
 test_that("Binary logistic functions work", {
+  skip_if_not_installed("modeldata")
+
   x20 <- .cal_table_logistic(segment_logistic, Class, .pred_good)
 
   model20 <- mgcv::gam(Class ~ s(.pred_good, k = 10),

--- a/tests/testthat/test-cal-validate.R
+++ b/tests/testthat/test-cal-validate.R
@@ -1,4 +1,6 @@
 test_that("Logistic validation with data frame input", {
+  skip_if_not_installed("rsample")
+
   df <- testthat_cal_sampled()
   val_obj <- cal_validate_logistic(df, Class)
   val_with_pred <- cal_validate_logistic(df, Class, save_pred = TRUE, smooth = TRUE)
@@ -59,6 +61,9 @@ test_that("Logistic validation with data frame input", {
 
 
 test_that("Beta validation with data frame input", {
+  skip_if_not_installed("betacal")
+  skip_if_not_installed("rsample")
+
   df <- testthat_cal_sampled()
   val_obj <- cal_validate_beta(df, Class)
   val_with_pred <- cal_validate_beta(df, Class, save_pred = TRUE)
@@ -87,6 +92,8 @@ test_that("Beta validation with data frame input", {
 
 
 test_that("Isotonic validation classification with data frame input", {
+  skip_if_not_installed("rsample")
+
   df <- testthat_cal_sampled()
   val_obj <- cal_validate_isotonic(df, Class)
   val_with_pred <- cal_validate_isotonic(df, Class, save_pred = TRUE)
@@ -114,6 +121,8 @@ test_that("Isotonic validation classification with data frame input", {
 })
 
 test_that("Bootstrapped Isotonic classification validation with data frame input", {
+  skip_if_not_installed("rsample")
+
   df <- testthat_cal_sampled()
   val_obj <- cal_validate_isotonic_boot(df, Class)
   val_with_pred <- cal_validate_isotonic_boot(df, Class, save_pred = TRUE)
@@ -141,6 +150,9 @@ test_that("Bootstrapped Isotonic classification validation with data frame input
 })
 
 test_that("Multinomial classification validation with data frame input", {
+  skip_if_not_installed("modeldata")
+  skip_if_not_installed("nnet")
+
   df <- rsample::vfold_cv(testthat_cal_sim_multi())
   val_obj <- cal_validate_multinomial(df, class)
   val_with_pred <- cal_validate_multinomial(df, class, save_pred = TRUE, smooth = TRUE)
@@ -350,6 +362,7 @@ test_that("Bootstrapped isotonic classification validation with `fit_resamples`"
 })
 
 test_that("Beta calibration validation with `fit_resamples`", {
+  skip_if_not_installed("betacal")
   res <- testthat_cal_fit_rs()
   val_obj <- cal_validate_beta(res$binary)
   val_with_pred <- cal_validate_beta(res$binary, save_pred = TRUE)
@@ -382,6 +395,9 @@ test_that("Beta calibration validation with `fit_resamples`", {
 })
 
 test_that("Multinomial calibration validation with `fit_resamples`", {
+  skip_if_not_installed("modeldata")
+  skip_if_not_installed("nnet")
+
   res <- testthat_cal_fit_rs()
   val_obj <- cal_validate_multinomial(res$multin)
   val_with_pred <- cal_validate_multinomial(res$multin, save_pred = TRUE, smooth = TRUE)
@@ -564,6 +580,10 @@ test_that("Isotonic bootstrapped regression validation with `fit_resamples`", {
 
 
 test_that("validation functions error with tune_results input", {
+  skip_if_not_installed("modeldata")
+  skip_if_not_installed("nnet")
+  skip_if_not_installed("beta")
+
   expect_snapshot_error(
     cal_validate_beta(testthat_cal_binary())
   )

--- a/tests/testthat/test-conformal-intervals-quantile.R
+++ b/tests/testthat/test-conformal-intervals-quantile.R
@@ -1,6 +1,7 @@
 test_that("split conformal quantile intervals", {
   skip_if_not_installed("modeldata")
   skip_if_not_installed("nnet")
+  skip_if_not_installed("quantregForest")
 
   # ----------------------------------------------------------------------------
 

--- a/vignettes/where-to-use.Rmd
+++ b/vignettes/where-to-use.Rmd
@@ -17,6 +17,8 @@ if (rlang::is_installed(c("modeldata", "rsample"))) {
   run <- TRUE
 } else {
   run <- FALSE
+  # For in-line code
+  correct_bad <- max_j_index_threshold <- NA
 }
 
 knitr::opts_chunk$set(

--- a/vignettes/where-to-use.Rmd
+++ b/vignettes/where-to-use.Rmd
@@ -12,7 +12,15 @@ editor_options:
 ---
 
 ```{r setup, include = FALSE}
+# For "no suggests" CRAN check
+if (rlang::is_installed(c("modeldata", "rsample"))) {
+  run <- TRUE
+} else {
+  run <- FALSE
+}
+
 knitr::opts_chunk$set(
+  eval = run,
   collapse = TRUE,
   comment = "#>",
   fig.width = 7,


### PR DESCRIPTION
Add a GH workflow that only directly installs "hard" dependencies, i.e. Depends, Imports, and LinkingTo dependencies. Notably, Suggests dependencies are never installed, with the exception of testthat, knitr, and rmarkdown. The cache is never used to avoid accidentally restoring a cache containing a suggested dependency.