### PR TITLE
turn off `smooth` if there are too few unique values for splines

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 * Fixed an issue where the `distance` metric appeared inconsistently when using `threshold_perf()` with custom metric sets (@jrwinget, #149).
 
+* `cal_estimate_linear()` and `cal_estimate_logistic()` now sets `smooth = FALSE` if data contains too few unique observations for splines to be fit, throwing a warning instead of an error (#167).
+
 # probably 1.0.3
 
 * Fixed a bug where the grouping for calibration methods was sensitive to the type of the grouping variables (#127).

--- a/R/cal-estimate-linear.R
+++ b/R/cal-estimate-linear.R
@@ -154,30 +154,7 @@ cal_linear_impl <- function(.data,
                             smooth,
                             source_class = NULL,
                             ...) {
-  if (smooth) {
-    estimate_name <- names(tidyselect::eval_select(enquo(estimate), .data))
-
-    if (inherits(.data, "grouped_df")) {
-      n_unique <- .data |> 
-        dplyr::summarise(
-          dplyr::across(dplyr::all_of(estimate_name), dplyr::n_distinct)
-        ) |>
-        dplyr::pull(dplyr::all_of(estimate_name)) |>
-        min()
-    } else {
-      n_unique <- dplyr::n_distinct(
-        dplyr::pull(.data, dplyr::all_of(estimate_name))
-      )
-    }
-
-    if (n_unique < 10) {
-      smooth <- FALSE
-      cli::cli_warn(
-        "Too few unique observations for spline-based calibrator.
-        Switching to linear."
-      )
-    }
-  }
+  smooth <- turn_off_smooth_if_too_few_unique(.data, enquo(estimate), smooth)
   
   if (smooth) {
     model <- "linear_spline"

--- a/R/cal-estimate-linear.R
+++ b/R/cal-estimate-linear.R
@@ -155,6 +155,31 @@ cal_linear_impl <- function(.data,
                             source_class = NULL,
                             ...) {
   if (smooth) {
+    estimate_name <- names(tidyselect::eval_select(enquo(estimate), .data))
+
+    if (inherits(.data, "grouped_df")) {
+      n_unique <- .data |> 
+        dplyr::summarise(
+          dplyr::across(dplyr::all_of(estimate_name), dplyr::n_distinct)
+        ) |>
+        dplyr::pull(dplyr::all_of(estimate_name)) |>
+        min()
+    } else {
+      n_unique <- dplyr::n_distinct(
+        dplyr::pull(.data, dplyr::all_of(estimate_name))
+      )
+    }
+
+    if (n_unique < 10) {
+      smooth <- FALSE
+      cli::cli_warn(
+        "Too few unique observations for spline-based calibrator.
+        Switching to linear."
+      )
+    }
+  }
+  
+  if (smooth) {
     model <- "linear_spline"
     method <- "Generalized additive model"
     additional_class <- "cal_estimate_linear_spline"

--- a/R/cal-estimate-linear.R
+++ b/R/cal-estimate-linear.R
@@ -154,8 +154,7 @@ cal_linear_impl <- function(.data,
                             smooth,
                             source_class = NULL,
                             ...) {
-  smooth <- turn_off_smooth_if_too_few_unique(.data, enquo(estimate), smooth)
-  
+
   if (smooth) {
     model <- "linear_spline"
     method <- "Generalized additive model"

--- a/R/cal-estimate-logistic.R
+++ b/R/cal-estimate-logistic.R
@@ -132,7 +132,6 @@ cal_logistic_impl <- function(.data,
                               smooth,
                               source_class = NULL,
                               ...) {
-  smooth <- turn_off_smooth_if_too_few_unique(.data, enquo(estimate), smooth)
 
   if (smooth) {
     model <- "logistic_spline"

--- a/R/cal-estimate-logistic.R
+++ b/R/cal-estimate-logistic.R
@@ -132,31 +132,7 @@ cal_logistic_impl <- function(.data,
                               smooth,
                               source_class = NULL,
                               ...) {
-  if (smooth) {
-    estimate_name <- names(tidyselect::eval_select(enquo(estimate), .data))
-    estimate_name <- estimate_name[length(estimate_name)]
-
-    if (inherits(.data, "grouped_df")) {
-      n_unique <- .data |> 
-        dplyr::summarise(
-          dplyr::across(dplyr::all_of(estimate_name), dplyr::n_distinct)
-        ) |>
-        dplyr::pull(dplyr::all_of(estimate_name)) |>
-        min()
-    } else {
-      n_unique <- dplyr::n_distinct(
-        dplyr::pull(.data, dplyr::all_of(estimate_name))
-      )
-    }
-
-    if (n_unique < 10) {
-      smooth <- FALSE
-      cli::cli_warn(
-        "Too few unique observations for spline-based calibrator.
-        Switching to logistic."
-      )
-    }
-  }
+  smooth <- turn_off_smooth_if_too_few_unique(.data, enquo(estimate), smooth)
 
   if (smooth) {
     model <- "logistic_spline"

--- a/R/cal-estimate-multinom.R
+++ b/R/cal-estimate-multinom.R
@@ -139,13 +139,8 @@ clean_env <- function(x) {
 }
 
 fit_multinomial_model <- function(.data, smooth, estimate, outcome, ...) {
-  # Check to see if the GAM is estimable given the data
-  if (smooth) {
-    smooth_ok <- check_data_for_gam(.data, estimate)
-    if (!smooth_ok) {
-      smooth <- FALSE
-    }
-  }
+  smooth <- turn_off_smooth_if_too_few_unique(.data, estimate, smooth)
+
   if (smooth) {
     # multinomial gams in mgcv needs zero-based integers as the outcome
     .data[[outcome]] <- as.numeric(.data[[outcome]]) - 1

--- a/R/cal-estimate-utils.R
+++ b/R/cal-estimate-utils.R
@@ -395,18 +395,17 @@ multinomial_f_from_str <- function(y, x) {
   res
 }
 
-check_data_for_gam <- function(.data, estimate, min_unique = 10) {
+turn_off_smooth_if_too_few_unique <- function(.data, estimate, smooth, min_vals = 10) {
   predictors <- .data[, estimate]
-  num_unique <- lapply(predictors, vctrs::vec_unique_count)
-  num_unique <- unlist(num_unique)
-  not_enough <- num_unique < min_unique
-  if (any(not_enough)) {
-    n <- sum(not_enough)
-    cli::cli_warn(
-      "Some prediction columns ({.val {names(not_enough)[not_enough]}}) had
-      fewer than {min_unique} unique values. An unsmoothed model will be used
-      instead.", call = NULL
-    )
+  if (smooth) {
+    n_unique <- purrr::map_int(predictors, vctrs::vec_unique_count)
+    if (min(n_unique) < min_vals) {
+      smooth <- FALSE
+      cli::cli_warn(
+        "Too few unique observations for spline-based calibrator.
+        Setting {.code smooth = FALSE}."
+      )
+    }
   }
-  !any(not_enough)
+  smooth
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -99,32 +99,3 @@ abort_if_grouped_df <- function(call = rlang::caller_env()) {
     call = call
   )
 }
-
-turn_off_smooth_if_too_few_unique <- function(.data, estimate, smooth) {
-  if (smooth) {
-    estimate_name <- names(tidyselect::eval_select(estimate, .data))
-    estimate_name <- estimate_name[length(estimate_name)]
-
-    if (inherits(.data, "grouped_df")) {
-      n_unique <- .data |> 
-        dplyr::summarise(
-          dplyr::across(dplyr::all_of(estimate_name), dplyr::n_distinct)
-        ) |>
-        dplyr::pull(dplyr::all_of(estimate_name)) |>
-        min()
-    } else {
-      n_unique <- dplyr::n_distinct(
-        dplyr::pull(.data, dplyr::all_of(estimate_name))
-      )
-    }
-
-    if (n_unique < 10) {
-      smooth <- FALSE
-      cli::cli_warn(
-        "Too few unique observations for spline-based calibrator.
-        Setting {.code smooth = FALSE}."
-      )
-    }
-  }
-  smooth
-}

--- a/tests/testthat/_snaps/cal-estimate.md
+++ b/tests/testthat/_snaps/cal-estimate.md
@@ -585,6 +585,23 @@
       Truth variable: `outcome`
       Estimate variable: `.pred`
 
+# Linear spline switches to linear if too few unique
+
+    Code
+      sl_gam <- cal_estimate_linear(boosting_predictions_oob, outcome, smooth = TRUE)
+    Condition
+      Warning:
+      Too few unique observations for spline-based calibrator. Switching to linear.
+
+---
+
+    Code
+      sl_gam <- cal_estimate_linear(boosting_predictions_oob, outcome, .by = id,
+        smooth = TRUE)
+    Condition
+      Warning:
+      Too few unique observations for spline-based calibrator. Switching to linear.
+
 # Non-default names used for estimate columns
 
     Code

--- a/tests/testthat/_snaps/cal-estimate.md
+++ b/tests/testthat/_snaps/cal-estimate.md
@@ -131,7 +131,7 @@
       sl_gam <- cal_estimate_logistic(segment_logistic, Class, smooth = TRUE)
     Condition
       Warning:
-      Too few unique observations for spline-based calibrator. Switching to logistic.
+      Too few unique observations for spline-based calibrator. Setting `smooth = FALSE`.
 
 ---
 
@@ -139,7 +139,7 @@
       sl_gam <- cal_estimate_logistic(segment_logistic, Class, .by = id, smooth = TRUE)
     Condition
       Warning:
-      Too few unique observations for spline-based calibrator. Switching to logistic.
+      Too few unique observations for spline-based calibrator. Setting `smooth = FALSE`.
 
 # Isotonic estimates work - data.frame
 
@@ -607,7 +607,7 @@
       sl_gam <- cal_estimate_linear(boosting_predictions_oob, outcome, smooth = TRUE)
     Condition
       Warning:
-      Too few unique observations for spline-based calibrator. Switching to linear.
+      Too few unique observations for spline-based calibrator. Setting `smooth = FALSE`.
 
 ---
 
@@ -616,7 +616,7 @@
         smooth = TRUE)
     Condition
       Warning:
-      Too few unique observations for spline-based calibrator. Switching to linear.
+      Too few unique observations for spline-based calibrator. Setting `smooth = FALSE`.
 
 # Non-default names used for estimate columns
 

--- a/tests/testthat/_snaps/cal-estimate.md
+++ b/tests/testthat/_snaps/cal-estimate.md
@@ -506,6 +506,42 @@
     x This function does not work with grouped data frames.
     i Apply `dplyr::ungroup()` and use the `.by` argument.
 
+# Linear spline switches to linear if too few unique
+
+    Code
+      sl_gam <- cal_estimate_linear(boosting_predictions_oob, outcome, smooth = TRUE)
+    Condition
+      Warning:
+      Too few unique observations for spline-based calibrator. Setting `smooth = FALSE`.
+
+---
+
+    Code
+      sl_gam <- cal_estimate_linear(boosting_predictions_oob, outcome, .by = id,
+        smooth = TRUE)
+    Condition
+      Warning:
+      Too few unique observations for spline-based calibrator. Setting `smooth = FALSE`.
+
+# Multinomial spline switches to linear if too few unique
+
+    Code
+      sl_gam <- cal_estimate_multinomial(smol_species_probs, Species, smooth = TRUE)
+    Condition
+      Warning:
+      Too few unique observations for spline-based calibrator. Setting `smooth = FALSE`.
+
+---
+
+    Code
+      sl_gam <- cal_estimate_multinomial(smol_by_species_probs, Species, .by = id,
+        smooth = TRUE)
+    Condition
+      Warning:
+      Too few unique observations for spline-based calibrator. Setting `smooth = FALSE`.
+      Warning:
+      Too few unique observations for spline-based calibrator. Setting `smooth = FALSE`.
+
 # Linear estimates work - data.frame
 
     Code
@@ -600,23 +636,6 @@
       Data points: 750, split in 10 groups
       Truth variable: `outcome`
       Estimate variable: `.pred`
-
-# Linear spline switches to linear if too few unique
-
-    Code
-      sl_gam <- cal_estimate_linear(boosting_predictions_oob, outcome, smooth = TRUE)
-    Condition
-      Warning:
-      Too few unique observations for spline-based calibrator. Setting `smooth = FALSE`.
-
----
-
-    Code
-      sl_gam <- cal_estimate_linear(boosting_predictions_oob, outcome, .by = id,
-        smooth = TRUE)
-    Condition
-      Warning:
-      Too few unique observations for spline-based calibrator. Setting `smooth = FALSE`.
 
 # Non-default names used for estimate columns
 

--- a/tests/testthat/_snaps/cal-estimate.md
+++ b/tests/testthat/_snaps/cal-estimate.md
@@ -125,6 +125,22 @@
       `.pred_class_1` ==> class_1
       `.pred_class_2` ==> class_2
 
+# Logistic spline switches to linear if too few unique
+
+    Code
+      sl_gam <- cal_estimate_logistic(segment_logistic, Class, smooth = TRUE)
+    Condition
+      Warning:
+      Too few unique observations for spline-based calibrator. Switching to logistic.
+
+---
+
+    Code
+      sl_gam <- cal_estimate_logistic(segment_logistic, Class, .by = id, smooth = TRUE)
+    Condition
+      Warning:
+      Too few unique observations for spline-based calibrator. Switching to logistic.
+
 # Isotonic estimates work - data.frame
 
     Code

--- a/tests/testthat/test-cal-estimate.R
+++ b/tests/testthat/test-cal-estimate.R
@@ -122,6 +122,7 @@ test_that("Logistic spline estimates work - tune_results", {
 
 test_that("Logistic spline switches to linear if too few unique", {
   skip_if_not_installed("modeldata")
+  skip("until refactored")
 
   segment_logistic$.pred_good <- rep(
     x = 1,
@@ -593,12 +594,13 @@ test_that("Linear spline estimates work - tune_results", {
 
 test_that("Linear spline switches to linear if too few unique", {
   skip_if_not_installed("modeldata")
+  skip("until refactored")
 
   boosting_predictions_oob$.pred <- rep(
     x = 1:5,
     length.out = nrow(boosting_predictions_oob)
   )
-  
+
   expect_snapshot(
     sl_gam <- cal_estimate_linear(boosting_predictions_oob, outcome, smooth = TRUE)
   )

--- a/tests/testthat/test-cal-estimate.R
+++ b/tests/testthat/test-cal-estimate.R
@@ -120,6 +120,39 @@ test_that("Logistic spline estimates work - tune_results", {
   )
 })
 
+test_that("Logistic spline switches to linear if too few unique", {
+  skip_if_not_installed("modeldata")
+
+  segment_logistic$.pred_good <- rep(
+    x = 1,
+    length.out = nrow(segment_logistic)
+  )
+
+  expect_snapshot(
+    sl_gam <- cal_estimate_logistic(segment_logistic, Class, smooth = TRUE)
+  )
+  sl_lm <- cal_estimate_logistic(segment_logistic, Class, smooth = FALSE)
+
+  expect_identical(
+    sl_gam,
+    sl_lm
+  )
+
+  segment_logistic$id <- rep(
+    x = 1:2,
+    length.out = nrow(segment_logistic)
+  )
+  expect_snapshot(
+    sl_gam <- cal_estimate_logistic(segment_logistic, Class, .by = id, smooth = TRUE)
+  )
+  sl_lm <- cal_estimate_logistic(segment_logistic, Class, .by = id, smooth = FALSE)
+
+  expect_identical(
+    sl_gam,
+    sl_lm
+  )
+})
+
 # --------------------------------- Isotonic -----------------------------------
 test_that("Isotonic estimates work - data.frame", {
   skip_if_not_installed("modeldata")

--- a/tests/testthat/test-cal-estimate.R
+++ b/tests/testthat/test-cal-estimate.R
@@ -496,6 +496,69 @@ test_that("Passing a binary outcome causes error", {
   )
 })
 
+test_that("Linear spline switches to linear if too few unique", {
+  skip_if_not_installed("modeldata")
+  skip("until refactored")
+
+  boosting_predictions_oob$.pred <- rep(
+    x = 1:5,
+    length.out = nrow(boosting_predictions_oob)
+  )
+
+  expect_snapshot(
+    sl_gam <- cal_estimate_linear(boosting_predictions_oob, outcome, smooth = TRUE)
+  )
+  sl_lm <- cal_estimate_linear(boosting_predictions_oob, outcome, smooth = FALSE)
+
+  expect_identical(
+    sl_gam,
+    sl_lm
+  )
+
+  expect_snapshot(
+    sl_gam <- cal_estimate_linear(boosting_predictions_oob, outcome, .by = id, smooth = TRUE)
+  )
+  sl_lm <- cal_estimate_linear(boosting_predictions_oob, outcome, .by = id, smooth = FALSE)
+
+  expect_identical(
+    sl_gam,
+    sl_lm
+  )
+})
+
+test_that("Multinomial spline switches to linear if too few unique", {
+  skip_if_not_installed("modeldata")
+
+  smol_species_probs <-
+    species_probs |>
+    slice_head(n = 2, by = Species)
+
+  expect_snapshot(
+    sl_gam <- cal_estimate_multinomial(smol_species_probs, Species, smooth = TRUE)
+  )
+  sl_glm <- cal_estimate_multinomial(smol_species_probs, Species, smooth = FALSE)
+
+  expect_identical(
+    sl_gam$estimates,
+    sl_glm$estimates
+  )
+
+  smol_by_species_probs <-
+    species_probs |>
+    slice_head(n = 4, by = Species) |>
+    mutate(id = rep(1:2, 6))
+
+  expect_snapshot(
+    sl_gam <- cal_estimate_multinomial(smol_by_species_probs, Species, .by = id, smooth = TRUE)
+  )
+  sl_glm <- cal_estimate_multinomial(smol_by_species_probs, Species, .by = id, smooth = FALSE)
+
+  expect_identical(
+    sl_gam$estimates,
+    sl_glm$estimates
+  )
+})
+
 # --------------------------------- Linear -----------------------------------
 test_that("Linear estimates work - data.frame", {
   skip_if_not_installed("modeldata")

--- a/tests/testthat/test-cal-estimate.R
+++ b/tests/testthat/test-cal-estimate.R
@@ -598,7 +598,7 @@ test_that("Linear spline switches to linear if too few unique", {
     x = 1:5,
     length.out = nrow(boosting_predictions_oob)
   )
-
+  
   expect_snapshot(
     sl_gam <- cal_estimate_linear(boosting_predictions_oob, outcome, smooth = TRUE)
   )

--- a/tests/testthat/test-cal-estimate.R
+++ b/tests/testthat/test-cal-estimate.R
@@ -558,6 +558,34 @@ test_that("Linear spline estimates work - tune_results", {
   )
 })
 
+test_that("Linear spline switches to linear if too few unique", {
+  skip_if_not_installed("modeldata")
+
+  boosting_predictions_oob$.pred <- rep(
+    x = 1:5,
+    length.out = nrow(boosting_predictions_oob)
+  )
+
+  expect_snapshot(
+    sl_gam <- cal_estimate_linear(boosting_predictions_oob, outcome, smooth = TRUE)
+  )
+  sl_lm <- cal_estimate_linear(boosting_predictions_oob, outcome, smooth = FALSE)
+
+  expect_identical(
+    sl_gam,
+    sl_lm
+  )
+
+  expect_snapshot(
+    sl_gam <- cal_estimate_linear(boosting_predictions_oob, outcome, .by = id, smooth = TRUE)
+  )
+  sl_lm <- cal_estimate_linear(boosting_predictions_oob, outcome, .by = id, smooth = FALSE)
+
+  expect_identical(
+    sl_gam,
+    sl_lm
+  )
+})
 
 # ----------------------------------- Other ------------------------------------
 test_that("Non-default names used for estimate columns", {

--- a/tests/testthat/test-cal-estimate.R
+++ b/tests/testthat/test-cal-estimate.R
@@ -531,7 +531,7 @@ test_that("Multinomial spline switches to linear if too few unique", {
 
   smol_species_probs <-
     species_probs |>
-    slice_head(n = 2, by = Species)
+    dplyr::slice_head(n = 2, by = Species)
 
   expect_snapshot(
     sl_gam <- cal_estimate_multinomial(smol_species_probs, Species, smooth = TRUE)
@@ -545,8 +545,8 @@ test_that("Multinomial spline switches to linear if too few unique", {
 
   smol_by_species_probs <-
     species_probs |>
-    slice_head(n = 4, by = Species) |>
-    mutate(id = rep(1:2, 6))
+    dplyr::slice_head(n = 4, by = Species) |>
+    dplyr::mutate(id = rep(1:2, 6))
 
   expect_snapshot(
     sl_gam <- cal_estimate_multinomial(smol_by_species_probs, Species, .by = id, smooth = TRUE)


### PR DESCRIPTION
To close https://github.com/tidymodels/probably/issues/155

This change happens if the number of unique within any of the groups is too low. To avoid a complicated "some groups use splines some do not" structure that would need to be added