### PR TITLE
smallest of typos

### DIFF
--- a/R/cal-estimate-utils.R
+++ b/R/cal-estimate-utils.R
@@ -167,7 +167,7 @@ get_prediction_data <- function(
     .by = NULL
 ) {
   if (!inherits(.data, "tbl_df")) {
-    data <- dplyr::as_tibble(.data)
+    .data <- dplyr::as_tibble(.data)
   }
 
   truth <- names(tidyselect::eval_select(rlang::enquo(truth), .data))


### PR DESCRIPTION
To close https://github.com/tidymodels/probably/issues/178

This little typo made it so the data wasn't actually turned into a tibble, which meant that when subsetting columns later it returned a vector instead of a 1 column data.frame