### PR TITLE
better error message for cal_validate_*()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # probably (development version)
 
+* Updated unit tests for new ggplot2 release (#180).
+
+* Better error message when using one of the `cal_validate_*()` functions with a validation set (#182). 
+
 # probably 1.1.0
 
 * Significant refactoring of the code underlying the calibration functions. The user-facing APIs have not changed. 

--- a/man/int_conformal_full.Rd
+++ b/man/int_conformal_full.Rd
@@ -111,28 +111,7 @@ intervals for the five new samples in parallel:
 predict(lm_conform, new_dat)
 }\if{html}{\out{</div>}}
 
-\if{html}{\out{<div class="sourceCode">}}\preformatted{## Warning in serialize(data, node$con, xdr = FALSE): 'package:workflowsets' may
-## not be available when loading
-## Warning in serialize(data, node$con, xdr = FALSE): 'package:workflowsets' may
-## not be available when loading
-## Warning in serialize(data, node$con, xdr = FALSE): 'package:workflowsets' may
-## not be available when loading
-## Warning in serialize(data, node$con, xdr = FALSE): 'package:workflowsets' may
-## not be available when loading
-## Warning in serialize(data, node$con, xdr = FALSE): 'package:workflowsets' may
-## not be available when loading
-## Warning in serialize(data, node$con, xdr = FALSE): 'package:workflowsets' may
-## not be available when loading
-## Warning in serialize(data, node$con, xdr = FALSE): 'package:workflowsets' may
-## not be available when loading
-## Warning in serialize(data, node$con, xdr = FALSE): 'package:workflowsets' may
-## not be available when loading
-## Warning in serialize(data, node$con, xdr = FALSE): 'package:workflowsets' may
-## not be available when loading
-## Warning in serialize(data, node$con, xdr = FALSE): 'package:workflowsets' may
-## not be available when loading
-
-## # A tibble: 5 x 2
+\if{html}{\out{<div class="sourceCode">}}\preformatted{## # A tibble: 5 x 2
 ##   .pred_lower .pred_upper
 ##         <dbl>       <dbl>
 ## 1       -17.9        59.6

--- a/tests/testthat/_snaps/cal-validate.md
+++ b/tests/testthat/_snaps/cal-validate.md
@@ -44,3 +44,59 @@
     This function can only be used with an <rset> object or the results of `tune::fit_resamples()` with a .predictions column.
     i Not an <tune_results> object.
 
+# validation sets fail with better message
+
+    Code
+      cal_validate_beta(mt_res)
+    Condition
+      Error in `cal_validate_beta()`:
+      ! For validation sets, please make a resampling object from the predictions prior to calling `cal_validate_beta()`
+
+---
+
+    Code
+      cal_validate_isotonic(mt_res)
+    Condition
+      Error in `cal_validate_isotonic()`:
+      ! For validation sets, please make a resampling object from the predictions prior to calling `cal_validate_isotonic()`
+
+---
+
+    Code
+      cal_validate_isotonic_boot(mt_res)
+    Condition
+      Error in `cal_validate_isotonic_boot()`:
+      ! For validation sets, please make a resampling object from the predictions prior to calling `cal_validate_isotonic_boot()`
+
+---
+
+    Code
+      cal_validate_linear(mt_res)
+    Condition
+      Error in `cal_validate_linear()`:
+      ! For validation sets, please make a resampling object from the predictions prior to calling `cal_validate_linear()`
+
+---
+
+    Code
+      cal_validate_logistic(mt_res)
+    Condition
+      Error in `cal_validate_logistic()`:
+      ! For validation sets, please make a resampling object from the predictions prior to calling `cal_validate_logistic()`
+
+---
+
+    Code
+      cal_validate_multinomial(mt_res)
+    Condition
+      Error in `cal_validate_multinomial()`:
+      ! For validation sets, please make a resampling object from the predictions prior to calling `cal_validate_multinomial()`
+
+---
+
+    Code
+      cal_validate_none(mt_res)
+    Condition
+      Error in `cal_validate_none()`:
+      ! For validation sets, please make a resampling object from the predictions prior to calling `cal_validate_none()`
+

--- a/tests/testthat/test-cal-validate-multiclass.R
+++ b/tests/testthat/test-cal-validate-multiclass.R
@@ -50,8 +50,8 @@ test_that("Isotonic validation with `fit_resamples` - Multiclass", {
   )
   skip_if_not_installed("tune", "1.2.0")
   expect_equal(
-    names(val_with_pred$.predictions_cal[[1]]),
-    c(".pred_one", ".pred_two", ".pred_three", ".row", "outcome", ".config", ".pred_class")
+    sort(names(val_with_pred$.predictions_cal[[1]])),
+    sort(c(".pred_one", ".pred_two", ".pred_three", ".row", "outcome", ".config", ".pred_class"))
   )
   expect_equal(
     purrr::map_int(val_with_pred$splits, ~ holdout_length(.x)),

--- a/tests/testthat/test-cal-validate.R
+++ b/tests/testthat/test-cal-validate.R
@@ -348,8 +348,8 @@ test_that("Logistic validation with `fit_resamples`", {
 
   skip_if_not_installed("tune", "1.2.0")
   expect_equal(
-    names(val_with_pred$.predictions_cal[[1]]),
-    c(".pred_class_1", ".pred_class_2", ".row", "outcome", ".config", ".pred_class")
+    sort(names(val_with_pred$.predictions_cal[[1]])),
+    sort(c(".pred_class_1", ".pred_class_2", ".row", "outcome", ".config", ".pred_class"))
   )
   expect_equal(
     purrr::map_int(val_with_pred$splits, ~ holdout_length(.x)),
@@ -380,8 +380,8 @@ test_that("Isotonic classification validation with `fit_resamples`", {
 
   skip_if_not_installed("tune", "1.2.0")
   expect_equal(
-    names(val_with_pred$.predictions_cal[[1]]),
-    c(".pred_class_1", ".pred_class_2", ".row", "outcome", ".config", ".pred_class")
+    sort(names(val_with_pred$.predictions_cal[[1]])),
+    sort(c(".pred_class_1", ".pred_class_2", ".row", "outcome", ".config", ".pred_class"))
   )
   expect_equal(
     purrr::map_int(val_with_pred$splits, ~ holdout_length(.x)),
@@ -413,8 +413,8 @@ test_that("Bootstrapped isotonic classification validation with `fit_resamples`"
 
   skip_if_not_installed("tune", "1.2.0")
   expect_equal(
-    names(val_with_pred$.predictions_cal[[1]]),
-    c(".pred_class_1", ".pred_class_2", ".row", "outcome", ".config", ".pred_class")
+    sort(names(val_with_pred$.predictions_cal[[1]])),
+    sort(c(".pred_class_1", ".pred_class_2", ".row", "outcome", ".config", ".pred_class"))
   )
   expect_equal(
     purrr::map_int(val_with_pred$splits, ~ holdout_length(.x)),
@@ -446,8 +446,8 @@ test_that("Beta calibration validation with `fit_resamples`", {
 
   skip_if_not_installed("tune", "1.2.0")
   expect_equal(
-    names(val_with_pred$.predictions_cal[[1]]),
-    c(".pred_class_1", ".pred_class_2", ".row", "outcome", ".config", ".pred_class")
+    sort(names(val_with_pred$.predictions_cal[[1]])),
+    sort(c(".pred_class_1", ".pred_class_2", ".row", "outcome", ".config", ".pred_class"))
   )
   expect_equal(
     purrr::map_int(val_with_pred$splits, ~ holdout_length(.x)),
@@ -481,8 +481,8 @@ test_that("Multinomial calibration validation with `fit_resamples`", {
 
   skip_if_not_installed("tune", "1.2.0")
   expect_equal(
-    names(val_with_pred$.predictions_cal[[1]]),
-    c(".pred_one", ".pred_two", ".pred_three", ".row", "outcome", ".config", ".pred_class")
+    sort(names(val_with_pred$.predictions_cal[[1]])),
+    sort(c(".pred_one", ".pred_two", ".pred_three", ".row", "outcome", ".config", ".pred_class"))
   )
   expect_equal(
     purrr::map_int(val_with_pred$splits, ~ holdout_length(.x)),
@@ -513,8 +513,8 @@ test_that("Validation without calibration with `fit_resamples`", {
 
   skip_if_not_installed("tune", "1.2.0")
   expect_equal(
-    names(val_with_pred$.predictions_cal[[1]]),
-    c(".pred_class_1", ".pred_class_2", ".row", "outcome", ".config", ".pred_class")
+    sort(names(val_with_pred$.predictions_cal[[1]])),
+    sort(c(".pred_class_1", ".pred_class_2", ".row", "outcome", ".config", ".pred_class"))
   )
   expect_equal(
     purrr::map_int(val_with_pred$splits, ~ holdout_length(.x)),
@@ -548,8 +548,8 @@ test_that("Linear validation with `fit_resamples`", {
 
   skip_if_not_installed("tune", "1.2.0")
   expect_equal(
-    names(val_with_pred$.predictions_cal[[1]]),
-    c(".pred", ".row", "outcome", ".config")
+    sort(names(val_with_pred$.predictions_cal[[1]])),
+    sort(c(".pred", ".row", "outcome", ".config"))
   )
   expect_equal(
     purrr::map_int(val_with_pred$splits, ~ holdout_length(.x)),
@@ -621,8 +621,8 @@ test_that("Isotonic regression validation with `fit_resamples`", {
 
   skip_if_not_installed("tune", "1.2.0")
   expect_equal(
-    names(val_with_pred$.predictions_cal[[1]]),
-    c(".pred", ".row", "outcome", ".config")
+    sort(names(val_with_pred$.predictions_cal[[1]])),
+    sort(c(".pred", ".row", "outcome", ".config"))
   )
   expect_equal(
     purrr::map_int(val_with_pred$splits, ~ holdout_length(.x)),
@@ -657,8 +657,8 @@ test_that("Isotonic bootstrapped regression validation with `fit_resamples`", {
 
   skip_if_not_installed("tune", "1.2.0")
   expect_equal(
-    names(val_with_pred$.predictions_cal[[1]]),
-    c(".pred", ".row", "outcome", ".config")
+    sort(names(val_with_pred$.predictions_cal[[1]])),
+    sort(c(".pred", ".row", "outcome", ".config"))
   )
   expect_equal(
     purrr::map_int(val_with_pred$splits, ~ holdout_length(.x)),
@@ -669,7 +669,6 @@ test_that("Isotonic bootstrapped regression validation with `fit_resamples`", {
 })
 
 # ------------------------------------------------------------------------------
-
 
 test_that("validation functions error with tune_results input", {
   skip_if_not_installed("modeldata")
@@ -697,4 +696,28 @@ test_that("validation functions error with tune_results input", {
   expect_snapshot_error(
     cal_validate_none(testthat_cal_binary())
   )
+})
+
+# ------------------------------------------------------------------------------
+
+test_that("validation sets fail with better message", {
+  library(tune)
+  set.seed(1)
+  mt_split <- rsample::initial_validation_split(mtcars)
+  mt_rset <- rsample::validation_set(mt_split)
+  mt_res <-
+    parsnip::linear_reg() |>
+    fit_resamples(
+      mpg ~ .,
+      resamples = mt_rset,
+      control = control_resamples(save_pred = TRUE)
+    )
+
+  expect_snapshot(cal_validate_beta(mt_res), error = TRUE)
+  expect_snapshot(cal_validate_isotonic(mt_res), error = TRUE)
+  expect_snapshot(cal_validate_isotonic_boot(mt_res), error = TRUE)
+  expect_snapshot(cal_validate_linear(mt_res), error = TRUE)
+  expect_snapshot(cal_validate_logistic(mt_res), error = TRUE)
+  expect_snapshot(cal_validate_multinomial(mt_res), error = TRUE)
+  expect_snapshot(cal_validate_none(mt_res), error = TRUE)
 })


### PR DESCRIPTION
Closes #182

The `sorts()` are there to prevent a reverse dependency issue in the next version of the tune. 